### PR TITLE
Define the theme data for OutlinedButton to fix its text foreground color.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -136,12 +136,13 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
             ]),
             Row(children: <Widget>[
-              OutlineButton(
-                onPressed: () => print('OutlineButton'),
+              OutlinedButton(
+                onPressed: () => print('OutlinedButton'),
                 child: const Text('Click me!'),
               ),
               SizedBox(width: 15),
-              OutlineButton(
+              OutlinedButton(
+                onPressed: null,
                 child: const Text("Can't click me!"),
               ),
             ]),

--- a/lib/yaru.dart
+++ b/lib/yaru.dart
@@ -92,6 +92,9 @@ final yaruTextTheme = TextTheme(
 final yaruButtonThemeData = ButtonThemeData(
     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.0)));
 
+final yaruOutlinedButtonThemeData = OutlinedButtonThemeData(
+    style: OutlinedButton.styleFrom(primary: yaruTextGrey));
+
 final yaruAppBarLightTheme = AppBarTheme(
   brightness: Brightness.light,
   color: yaruWarmGrey,
@@ -123,6 +126,7 @@ final yaruTheme = ThemeData(
     applyElevationOverlayColor: false,
     colorScheme: yaruLightColorScheme,
     buttonTheme: yaruButtonThemeData,
+    outlinedButtonTheme: yaruOutlinedButtonThemeData,
     appBarTheme: yaruAppBarDarkTheme);
 
 final yaruLightTheme = ThemeData(


### PR DESCRIPTION
Use OutlinedButtons in the example app, as OutlineButton is obsolete.