### PR TITLE
Example: Replace or correct (deprecated) Widgets

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -126,13 +126,15 @@ class _MyHomePageState extends State<MyHomePage> {
               style: Theme.of(context).textTheme.overline,
             ),
             Row(children: <Widget>[
-              FlatButton(
+              TextButton(
                 onPressed: () => print('FlatButton'),
                 child: const Text('Click me!'),
               ),
               SizedBox(width: 15),
-              FlatButton(
+              TextButton(
+                onPressed: null,
                 child: const Text("Can't click me!"),
+                autofocus: true,
               ),
             ]),
             Row(children: <Widget>[
@@ -147,19 +149,20 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
             ]),
             Row(children: <Widget>[
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => print('RaisedButton'),
                 child: const Text('Click me!'),
               ),
               SizedBox(width: 15),
-              RaisedButton(
+              ElevatedButton(
+                onPressed: null,
                 child: const Text("Can't click me!"),
               ),
             ]),
             Row(
               children: <Widget>[
                 DropdownButton<int>(
-                  onChanged: (value) => print('DropdownButton ${value}'),
+                  onChanged: (value) => print('DropdownButton $value'),
                   value: 1,
                   items: <DropdownMenuItem<int>>[
                     DropdownMenuItem(value: 1, child: Text('One')),
@@ -188,7 +191,10 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                     Row(
                       children: <Widget>[
-                        Checkbox(value: true),
+                        Checkbox(
+                          value: true,
+                          onChanged: null,
+                        ),
                         Text('Disabled'),
                       ],
                     ),
@@ -211,7 +217,10 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                     Row(
                       children: <Widget>[
-                        Switch(value: true),
+                        Switch(
+                          value: true,
+                          onChanged: (bool value) {},
+                        ),
                         Text('Disabled'),
                       ],
                     ),
@@ -234,7 +243,11 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                     Row(
                       children: <Widget>[
-                        Radio(value: 3, groupValue: 1),
+                        Radio(
+                          value: 3,
+                          groupValue: 1,
+                          onChanged: (int value) {},
+                        ),
                         Text('Disabled'),
                       ],
                     ),

--- a/example/linux/flutter/CMakeLists.txt
+++ b/example/linux/flutter/CMakeLists.txt
@@ -81,6 +81,7 @@ add_custom_command(
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
       linux-x64 ${CMAKE_BUILD_TYPE}
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/example/linux/flutter/CMakeLists.txt
+++ b/example/linux/flutter/CMakeLists.txt
@@ -81,7 +81,6 @@ add_custom_command(
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
       linux-x64 ${CMAKE_BUILD_TYPE}
-  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"


### PR DESCRIPTION
Some Widgets were deprecated

- FlatButton -> TextButton
- RaisedButton -> ElevatedButton
- correct CheckBox, Switch and Radio key, value scaffolding
- remove curtly bracets in DropDownButton onChanged print