### PR TITLE
Theme fixes and circ progress addition

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -224,6 +224,9 @@ class _MyHomePageState extends State<MyHomePage> {
                         Text('Disabled'),
                       ],
                     ),
+                    Row(
+                      children: <Widget>[CircularProgressIndicator()],
+                    )
                   ],
                 ),
                 Column(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -219,7 +219,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       children: <Widget>[
                         Switch(
                           value: true,
-                          onChanged: (bool value) {},
+                          onChanged: null,
                         ),
                         Text('Disabled'),
                       ],
@@ -249,7 +249,7 @@ class _MyHomePageState extends State<MyHomePage> {
                         Radio(
                           value: 3,
                           groupValue: 1,
-                          onChanged: (int value) {},
+                          onChanged: null,
                         ),
                         Text('Disabled'),
                       ],

--- a/lib/yaru.dart
+++ b/lib/yaru.dart
@@ -256,43 +256,27 @@ final elevatedButtonThemeDataDark = ElevatedButtonThemeData(
 
 // Switches
 Color getSwitchThumbColorDark(Set<MaterialState> states) {
-  const Set<MaterialState> interactiveStates = <MaterialState>{
-    MaterialState.pressed,
-    MaterialState.focused,
-    MaterialState.dragged,
-    MaterialState.selected
-  };
-  const Set<MaterialState> disabledStates = <MaterialState>{
-    MaterialState.disabled
-  };
-
-  if (states.any(interactiveStates.contains)) {
-    return yaruLightAubergine;
+  if (states.contains(MaterialState.disabled)) {
+    return yaruWarmGrey;
+  } else {
+    if (states.contains(MaterialState.selected)) {
+      return yaruMidAubergine;
+    } else {
+      return yaruWhite;
+    }
   }
-  if (states.any(disabledStates.contains)) {
-    return yaruDisabledGreyDark;
-  }
-  return yaruWhite;
 }
 
 Color getSwitchTrackColorDark(Set<MaterialState> states) {
-  const Set<MaterialState> interactiveStates = <MaterialState>{
-    MaterialState.pressed,
-    MaterialState.focused,
-    MaterialState.selected,
-    MaterialState.dragged
-  };
-  const Set<MaterialState> disabledStates = <MaterialState>{
-    MaterialState.disabled
-  };
-
-  if (states.any(interactiveStates.contains)) {
-    return yaruMidAubergine;
-  }
-  if (states.contains(disabledStates)) {
+  if (states.contains(MaterialState.disabled)) {
     return yaruDisabledGreyDark;
+  } else {
+    if (states.contains(MaterialState.selected)) {
+      return yaruMidAubergine;
+    } else {
+      return yaruWarmGrey;
+    }
   }
-  return yaruWarmGrey;
 }
 
 final switchStyleDark = SwitchThemeData(
@@ -301,41 +285,20 @@ final switchStyleDark = SwitchThemeData(
 
 // Checks
 Color getCheckFillColorDark(Set<MaterialState> states) {
-  const Set<MaterialState> interactiveStates = <MaterialState>{
-    MaterialState.pressed,
-    MaterialState.focused,
-    MaterialState.selected,
-    MaterialState.dragged
-  };
-  const Set<MaterialState> disabledStates = <MaterialState>{
-    MaterialState.disabled
-  };
-  if (states.any(interactiveStates.contains)) {
-    return yaruMidAubergine;
+  if (!states.contains(MaterialState.disabled)) {
+    if (states.contains(MaterialState.selected)) {
+      return yaruLightAubergine;
+    }
+    return yaruWarmGrey;
   }
-  if (states.any(disabledStates.contains)) {
-    return yaruDisabledGreyDark;
-  }
-  return yaruWarmGrey;
+  return yaruDisabledGreyDark;
 }
 
 Color getCheckColorDark(Set<MaterialState> states) {
-  const Set<MaterialState> interactiveStates = <MaterialState>{
-    MaterialState.pressed,
-    MaterialState.focused,
-    MaterialState.selected,
-    MaterialState.dragged
-  };
-  const Set<MaterialState> disabledStates = <MaterialState>{
-    MaterialState.disabled
-  };
-  if (states.any(interactiveStates.contains)) {
+  if (!states.contains(MaterialState.disabled)) {
     return yaruWhite;
   }
-  if (states.any(disabledStates.contains)) {
-    return yaruDisabledGreyDark;
-  }
-  return yaruWhite;
+  return yaruWarmGrey;
 }
 
 final checkStyle = CheckboxThemeData(

--- a/lib/yaru.dart
+++ b/lib/yaru.dart
@@ -20,6 +20,7 @@ final yaruErrorColor = Color(0xFFFF0000);
 // more colors, as the canonical palette is not enough
 final yaruGreen = Color(0xFF109a26);
 final yaruDisabledGreyDark = Color(0xFF535353);
+final yaruMidAubergineTransparentized = Color(0xAA5E2750);
 
 final yaruLightColorScheme = ColorScheme.fromSwatch(
     // NOTE(robert-ancell): Light shades from 'Tint' on website, dark shades calculated.
@@ -272,7 +273,7 @@ Color getSwitchTrackColorDark(Set<MaterialState> states) {
     return yaruDisabledGreyDark;
   } else {
     if (states.contains(MaterialState.selected)) {
-      return yaruMidAubergine;
+      return yaruMidAubergineTransparentized;
     } else {
       return yaruWarmGrey;
     }

--- a/lib/yaru.dart
+++ b/lib/yaru.dart
@@ -15,12 +15,11 @@ final yaruWarmGrey = Color(0xFFAEA79F);
 final yaruCoolGrey = Color(0xFF333333);
 final yaruTextGrey = Color(0xFF111111);
 final yaruCanonicalAubergine = Color(0xFF772953);
-final yaruGreen = Color(0xFF109a26);
 final yaruErrorColor = Color(0xFFFF0000);
 
-final elevatedButtonThemeData = ElevatedButtonThemeData(
-    style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.all<Color>(yaruGreen)));
+// more colors, as the canonical palette is not enough
+final yaruGreen = Color(0xFF109a26);
+final yaruDisabledGreyDark = Color(0xFF535353);
 
 final yaruLightColorScheme = ColorScheme.fromSwatch(
     // NOTE(robert-ancell): Light shades from 'Tint' on website, dark shades calculated.
@@ -150,7 +149,7 @@ final yaruTheme = ThemeData(
     applyElevationOverlayColor: false,
     colorScheme: yaruLightColorScheme,
     buttonTheme: yaruButtonThemeData,
-    elevatedButtonTheme: elevatedButtonThemeData,
+    elevatedButtonTheme: elevatedButtonThemeDataLight,
     outlinedButtonTheme: yaruOutlinedButtonThemeData,
     appBarTheme: yaruAppBarDarkTheme);
 
@@ -175,15 +174,15 @@ final yaruLightTheme = ThemeData(
     applyElevationOverlayColor: false,
     colorScheme: yaruLightColorScheme,
     buttonTheme: yaruButtonThemeData,
-    elevatedButtonTheme: elevatedButtonThemeData,
+    elevatedButtonTheme: elevatedButtonThemeDataLight,
     outlinedButtonTheme: yaruOutlinedButtonThemeData,
     appBarTheme: yaruAppBarLightTheme);
 
 final yaruDarkTheme = ThemeData(
     brightness: Brightness.dark,
-    primaryColor: yaruDarkColorScheme.surface,
+    primaryColor: yaruDarkColorScheme.primary,
     primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(yaruDarkColorScheme.surface),
+        ThemeData.estimateBrightnessForColor(yaruDarkColorScheme.primary),
     canvasColor: yaruDarkColorScheme.background,
     accentColor: yaruDarkColorScheme.secondary,
     accentColorBrightness:
@@ -200,6 +199,149 @@ final yaruDarkTheme = ThemeData(
     applyElevationOverlayColor: true,
     colorScheme: yaruDarkColorScheme,
     buttonTheme: yaruButtonThemeData,
-    elevatedButtonTheme: elevatedButtonThemeData,
+    elevatedButtonTheme: elevatedButtonThemeDataDark,
     outlinedButtonTheme: yaruDarkOutlinedButtonThemeData,
+    switchTheme: switchStyleDark,
+    checkboxTheme: checkStyle,
+    radioTheme: radioStyle,
+    primaryColorDark: yaruUbuntuOrange,
     appBarTheme: yaruAppBarDarkTheme);
+
+// Special casing some widgets
+// That are not catched with the default theming in flutter
+// "Green" elevated Buttons
+Color getElevatedButtonColorLight(Set<MaterialState> states) {
+  const Set<MaterialState> interactiveStates = <MaterialState>{
+    MaterialState.pressed,
+    MaterialState.hovered,
+    MaterialState.focused,
+  };
+  const Set<MaterialState> disabledStates = <MaterialState>{
+    MaterialState.disabled
+  };
+  if (states.any(interactiveStates.contains)) {
+    return yaruGreen;
+  } else if (states.any(disabledStates.contains)) {
+    return yaruWarmGrey;
+  }
+  return yaruGreen;
+}
+
+Color getElevatedButtonColorDark(Set<MaterialState> states) {
+  const Set<MaterialState> interactiveStates = <MaterialState>{
+    MaterialState.pressed,
+    MaterialState.hovered,
+    MaterialState.focused,
+  };
+  const Set<MaterialState> disabledStates = <MaterialState>{
+    MaterialState.disabled
+  };
+  if (states.any(interactiveStates.contains)) {
+    return yaruGreen;
+  } else if (states.any(disabledStates.contains)) {
+    return yaruDisabledGreyDark;
+  }
+  return yaruGreen;
+}
+
+final elevatedButtonThemeDataLight = ElevatedButtonThemeData(
+    style: ButtonStyle(
+        backgroundColor:
+            MaterialStateProperty.resolveWith(getElevatedButtonColorLight)));
+
+final elevatedButtonThemeDataDark = ElevatedButtonThemeData(
+    style: ButtonStyle(
+        backgroundColor:
+            MaterialStateProperty.resolveWith(getElevatedButtonColorDark)));
+
+// Switches
+Color getSwitchThumbColorDark(Set<MaterialState> states) {
+  const Set<MaterialState> interactiveStates = <MaterialState>{
+    MaterialState.pressed,
+    MaterialState.focused,
+    MaterialState.dragged,
+    MaterialState.selected
+  };
+  const Set<MaterialState> disabledStates = <MaterialState>{
+    MaterialState.disabled
+  };
+
+  if (states.any(interactiveStates.contains)) {
+    return yaruLightAubergine;
+  }
+  if (states.any(disabledStates.contains)) {
+    return yaruDisabledGreyDark;
+  }
+  return yaruWhite;
+}
+
+Color getSwitchTrackColorDark(Set<MaterialState> states) {
+  const Set<MaterialState> interactiveStates = <MaterialState>{
+    MaterialState.pressed,
+    MaterialState.focused,
+    MaterialState.selected,
+    MaterialState.dragged
+  };
+  const Set<MaterialState> disabledStates = <MaterialState>{
+    MaterialState.disabled
+  };
+
+  if (states.any(interactiveStates.contains)) {
+    return yaruMidAubergine;
+  }
+  if (states.contains(disabledStates)) {
+    return yaruDisabledGreyDark;
+  }
+  return yaruWarmGrey;
+}
+
+final switchStyleDark = SwitchThemeData(
+    thumbColor: MaterialStateProperty.resolveWith(getSwitchThumbColorDark),
+    trackColor: MaterialStateProperty.resolveWith(getSwitchTrackColorDark));
+
+// Checks
+Color getCheckFillColorDark(Set<MaterialState> states) {
+  const Set<MaterialState> interactiveStates = <MaterialState>{
+    MaterialState.pressed,
+    MaterialState.focused,
+    MaterialState.selected,
+    MaterialState.dragged
+  };
+  const Set<MaterialState> disabledStates = <MaterialState>{
+    MaterialState.disabled
+  };
+  if (states.any(interactiveStates.contains)) {
+    return yaruMidAubergine;
+  }
+  if (states.any(disabledStates.contains)) {
+    return yaruDisabledGreyDark;
+  }
+  return yaruWarmGrey;
+}
+
+Color getCheckColorDark(Set<MaterialState> states) {
+  const Set<MaterialState> interactiveStates = <MaterialState>{
+    MaterialState.pressed,
+    MaterialState.focused,
+    MaterialState.selected,
+    MaterialState.dragged
+  };
+  const Set<MaterialState> disabledStates = <MaterialState>{
+    MaterialState.disabled
+  };
+  if (states.any(interactiveStates.contains)) {
+    return yaruWhite;
+  }
+  if (states.any(disabledStates.contains)) {
+    return yaruDisabledGreyDark;
+  }
+  return yaruWhite;
+}
+
+final checkStyle = CheckboxThemeData(
+    fillColor: MaterialStateProperty.resolveWith(getCheckFillColorDark),
+    checkColor: MaterialStateProperty.resolveWith(getCheckColorDark));
+
+// Radios
+final radioStyle = RadioThemeData(
+    fillColor: MaterialStateProperty.resolveWith(getCheckFillColorDark));

--- a/lib/yaru.dart
+++ b/lib/yaru.dart
@@ -15,8 +15,12 @@ final yaruWarmGrey = Color(0xFFAEA79F);
 final yaruCoolGrey = Color(0xFF333333);
 final yaruTextGrey = Color(0xFF111111);
 final yaruCanonicalAubergine = Color(0xFF772953);
-
+final yaruGreen = Color(0xFF109a26);
 final yaruErrorColor = Color(0xFFFF0000);
+
+final elevatedButtonThemeData = ElevatedButtonThemeData(
+    style: ButtonStyle(
+        backgroundColor: MaterialStateProperty.all<Color>(yaruGreen)));
 
 final yaruLightColorScheme = ColorScheme.fromSwatch(
     // NOTE(robert-ancell): Light shades from 'Tint' on website, dark shades calculated.
@@ -33,7 +37,7 @@ final yaruLightColorScheme = ColorScheme.fromSwatch(
       900: Color(0xFF2F1106),
     }),
     primaryColorDark: yaruCoolGrey,
-    accentColor: yaruUbuntuOrange,
+    accentColor: yaruLightAubergine,
     cardColor: yaruWhite,
     backgroundColor: yaruWhite,
     errorColor: yaruErrorColor,
@@ -54,7 +58,7 @@ final yaruDarkColorScheme = ColorScheme.fromSwatch(
       900: Color(0xFF2F1106),
     }),
     primaryColorDark: yaruCoolGrey,
-    accentColor: yaruUbuntuOrange,
+    accentColor: yaruLightAubergine,
     cardColor: yaruCoolGrey,
     backgroundColor: yaruCoolGrey,
     errorColor: yaruErrorColor,
@@ -99,7 +103,7 @@ final yaruTextTheme = TextTheme(
     overline: yaruOverlineStyle);
 
 final yaruButtonThemeData = ButtonThemeData(
-    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.0)));
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4.0)));
 
 final yaruOutlinedButtonThemeData = OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(primary: yaruTextGrey));
@@ -142,10 +146,11 @@ final yaruTheme = ThemeData(
     dialogBackgroundColor: yaruLightColorScheme.background,
     errorColor: yaruLightColorScheme.error,
     textTheme: yaruTextTheme,
-    indicatorColor: yaruLightColorScheme.onPrimary,
+    indicatorColor: yaruLightColorScheme.secondary,
     applyElevationOverlayColor: false,
     colorScheme: yaruLightColorScheme,
     buttonTheme: yaruButtonThemeData,
+    elevatedButtonTheme: elevatedButtonThemeData,
     outlinedButtonTheme: yaruOutlinedButtonThemeData,
     appBarTheme: yaruAppBarDarkTheme);
 
@@ -166,10 +171,11 @@ final yaruLightTheme = ThemeData(
     dialogBackgroundColor: yaruLightColorScheme.background,
     errorColor: yaruLightColorScheme.error,
     textTheme: yaruTextTheme,
-    indicatorColor: yaruLightColorScheme.onPrimary,
+    indicatorColor: yaruLightColorScheme.secondary,
     applyElevationOverlayColor: false,
     colorScheme: yaruLightColorScheme,
     buttonTheme: yaruButtonThemeData,
+    elevatedButtonTheme: elevatedButtonThemeData,
     outlinedButtonTheme: yaruOutlinedButtonThemeData,
     appBarTheme: yaruAppBarLightTheme);
 
@@ -190,9 +196,10 @@ final yaruDarkTheme = ThemeData(
     dialogBackgroundColor: yaruDarkColorScheme.background,
     errorColor: yaruDarkColorScheme.error,
     textTheme: yaruTextTheme,
-    indicatorColor: yaruDarkColorScheme.onPrimary,
+    indicatorColor: yaruDarkColorScheme.secondary,
     applyElevationOverlayColor: true,
     colorScheme: yaruDarkColorScheme,
     buttonTheme: yaruButtonThemeData,
+    elevatedButtonTheme: elevatedButtonThemeData,
     outlinedButtonTheme: yaruDarkOutlinedButtonThemeData,
     appBarTheme: yaruAppBarDarkTheme);


### PR DESCRIPTION
- add yaruGreen to the palette
- ElevatedButton color is now green just like in yaru gtk/shell
- checkbox/radio/progressindicator color is now purple just like in yaru gtk/shell
- make buttons less round to match yaru
- add CircularProgressIndicator to the example app
- add helper methods/functions to get the correct switch/check/radio colors for the dark theme

![grafik](https://user-images.githubusercontent.com/15329494/106917134-4336db80-6708-11eb-9ab3-f3f824f91c27.png)

![grafik](https://user-images.githubusercontent.com/15329494/106917243-5cd82300-6708-11eb-99b0-159349ea3f15.png)



Depends on #8 

