### PR TITLE
Revert "`effective_dart` added (#22)"

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,0 @@
-include: package:effective_dart/analysis_options.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-dev_dependencies:
-  effective_dart: ^1.3.0
-
 flutter:
   fonts:
     - family: Ubuntu


### PR DESCRIPTION
This reverts commit 00def7052eaedf66b87b5ed718070e8a672b0f56.

Sorry @iapicca I had a bit fast fingers here. We need to get this into main branch without flooding the workspace with warnings. Thus reverting this for now. Re-opened the issue