### PR TITLE
Revert "Migrate to null-safety"

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,7 +33,7 @@ class _MyAppState extends State<MyApp> {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, required this.themeChanged}) : super(key: key);
+  const MyHomePage({Key key, this.themeChanged}) : super(key: key);
 
   final void Function(String themeName) themeChanged;
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: Ubuntu Yaru Style - Distinct look and feel of the Ubuntu Desktop
 homepage: https://github.com/ubuntu/yaru.dart
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Reverts ubuntu/yaru.dart#30

Sorry @jpnurmi but currently we can not update this, because the ubuntu-installer still uses 2.7

Thus reverting this. 