### PR TITLE
Remove "clang-format off" comments from in CCfiles

### DIFF
--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,8 +2,6 @@
 //  Generated file. Do not edit.
 //
 
-// clang-format off
-
 #include "generated_plugin_registrant.h"
 
 

--- a/example/linux/flutter/generated_plugin_registrant.h
+++ b/example/linux/flutter/generated_plugin_registrant.h
@@ -2,8 +2,6 @@
 //  Generated file. Do not edit.
 //
 
-// clang-format off
-
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 


### PR DESCRIPTION
They were auto generated by vscode after upgrading my local flutter installation.
Committing them as advised in #36 