### PR TITLE
Improve dark and light theme contrast

### DIFF
--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -24,7 +24,7 @@ final _lightColorScheme = ColorScheme.fromSwatch(
   primaryColorDark: yaru.Colors.coolGrey,
   accentColor: yaru.Colors.lightAubergine,
   cardColor: Colors.white,
-  backgroundColor: Colors.white,
+  backgroundColor: yaru.Colors.porcelain,
   errorColor: yaru.Colors.red,
   brightness: Brightness.light,
 );
@@ -63,7 +63,7 @@ final _textButtonThemeData = TextButtonThemeData(
 
 final _appBarLightTheme = AppBarTheme(
   brightness: Brightness.light,
-  color: Colors.white,
+  color: yaru.Colors.porcelain,
   textTheme: textTheme.copyWith(
     headline6: textTheme.headline6!.copyWith(
       color: yaru.Colors.coolGrey,
@@ -77,7 +77,7 @@ final _appBarLightTheme = AppBarTheme(
 
 final _appBarDarkTheme = AppBarTheme(
   brightness: Brightness.dark,
-  color: yaru.Colors.coolGrey,
+  color: yaru.Colors.inkstone,
 );
 
 final theme = ThemeData(

--- a/lib/src/utils/colors.dart
+++ b/lib/src/utils/colors.dart
@@ -88,4 +88,7 @@ class Colors {
   static const Color red = Color(0xFFCC0000);
   static const Color green = Color(0xFF109a26);
   static const Color disabledGreyDark = Color(0xFF535353);
+  static const Color porcelain = Color(0xFFF7F7F7);
+  static const Color inkstone = Color(0xFF3B3B3B);
+  static const Color jet = Color(0xFF1D1D1D);
 }


### PR DESCRIPTION
- lightheme: Improve contrast by alternating from light
- dark theme use inkstone for the appbar

![Bildschirmfoto von 2021-05-07 16-25-25](https://user-images.githubusercontent.com/15329494/117464688-34530580-af51-11eb-912b-5e457a643262.png)
![Bildschirmfoto von 2021-05-07 16-27-12](https://user-images.githubusercontent.com/15329494/117464691-34eb9c00-af51-11eb-9ab6-e6afb295ea2c.png)

Closes #59 #58  