### PR TITLE
Prepare 0.0.5 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.0.5
+
+* [Frederik Feichtmeier](https://github.com/Feichtmeier)
+  *  Reduce themes to 2 and update light/dark mode button (#63)
+
 # 0.0.4
 
 * [Frederik Feichtmeier](https://github.com/Feichtmeier)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 # 0.0.5
 
 * [Frederik Feichtmeier](https://github.com/Feichtmeier)
-  *  Reduce themes to 2 and update light/dark mode button (#63)
+  * Reduce themes to 2 and update light/dark mode button (#63)
+  * Fixes and improvements for Flutter 2.3 (#64)
 
 # 0.0.4
 

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -40,55 +40,12 @@ final _darkColorScheme = ColorScheme.fromSwatch(
   brightness: Brightness.dark,
 );
 
-final _buttonThemeData = ButtonThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(4.0),
-  ),
-);
-
-final _outlinedButtonThemeData = OutlinedButtonThemeData(
-    style: OutlinedButton.styleFrom(
-  visualDensity: VisualDensity.standard,
-  primary: yaru.Colors.textGrey,
-));
-
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
-    style: OutlinedButton.styleFrom(
-  visualDensity: VisualDensity.standard,
-  primary: Colors.white,
-));
-
-final _textButtonThemeData = TextButtonThemeData(
-    style: TextButton.styleFrom(visualDensity: VisualDensity.standard));
-
-final _appBarLightTheme = AppBarTheme(
-  brightness: Brightness.light,
-  color: yaru.Colors.porcelain,
-  textTheme: textTheme.copyWith(
-    headline6: textTheme.headline6!.copyWith(
-      color: yaru.Colors.coolGrey,
-      fontSize: 20,
-      fontWeight: FontWeight.w500,
-    ),
-  ),
-  iconTheme: IconThemeData(color: yaru.Colors.coolGrey),
-  actionsIconTheme: IconThemeData(color: yaru.Colors.coolGrey),
-);
-
-final _appBarDarkTheme = AppBarTheme(
-  brightness: Brightness.dark,
-  color: yaru.Colors.inkstone,
-);
-
 final lightTheme = ThemeData(
   brightness: Brightness.light,
   primaryColor: _lightColorScheme.primary,
   primaryColorBrightness:
       ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
   canvasColor: _lightColorScheme.background,
-  accentColor: _lightColorScheme.secondary,
-  accentColorBrightness:
-      ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
   scaffoldBackgroundColor: _lightColorScheme.background,
   bottomAppBarColor: _lightColorScheme.surface,
   cardColor: _lightColorScheme.surface,
@@ -98,19 +55,24 @@ final lightTheme = ThemeData(
   errorColor: _lightColorScheme.error,
   textTheme: _textTheme,
   indicatorColor: _lightColorScheme.secondary,
+  progressIndicatorTheme:
+      ProgressIndicatorThemeData(color: _lightColorScheme.secondary),
   applyElevationOverlayColor: false,
   colorScheme: _lightColorScheme,
   buttonTheme: _buttonThemeData,
-  elevatedButtonTheme: _elevatedButtonThemeData,
+  elevatedButtonTheme: _elevatedButtonThemeDataLight,
   outlinedButtonTheme: _outlinedButtonThemeData,
   textButtonTheme: _textButtonThemeData,
+  switchTheme: _switchStyleLight,
+  checkboxTheme: _checkStyleLight,
+  radioTheme: _radioStyleLight,
   appBarTheme: _appBarLightTheme,
   floatingActionButtonTheme: FloatingActionButtonThemeData(
     backgroundColor: yaru.Colors.green,
   ),
   bottomNavigationBarTheme: BottomNavigationBarThemeData(
     selectedItemColor: _lightColorScheme.primary,
-    unselectedItemColor: _lightColorScheme.onSurface.withOpacity(0.7),
+    unselectedItemColor: yaru.Colors.coolGrey,
   ),
 );
 
@@ -120,9 +82,6 @@ final darkTheme = ThemeData(
   primaryColorBrightness:
       ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
   canvasColor: _darkColorScheme.background,
-  accentColor: _darkColorScheme.secondary,
-  accentColorBrightness:
-      ThemeData.estimateBrightnessForColor(_darkColorScheme.secondary),
   scaffoldBackgroundColor: _darkColorScheme.background,
   bottomAppBarColor: _darkColorScheme.surface,
   cardColor: _darkColorScheme.surface,
@@ -132,6 +91,8 @@ final darkTheme = ThemeData(
   errorColor: _darkColorScheme.error,
   textTheme: _textTheme,
   indicatorColor: _darkColorScheme.secondary,
+  progressIndicatorTheme:
+      ProgressIndicatorThemeData(color: _darkColorScheme.secondary),
   applyElevationOverlayColor: true,
   colorScheme: _darkColorScheme,
   buttonTheme: _buttonThemeData,
@@ -139,22 +100,46 @@ final darkTheme = ThemeData(
   elevatedButtonTheme: _elevatedButtonThemeDataDark,
   outlinedButtonTheme: _darkOutlinedButtonThemeData,
   switchTheme: _switchStyleDark,
-  checkboxTheme: _checkStyle,
-  radioTheme: _radioStyle,
+  checkboxTheme: _checkStyleDark,
+  radioTheme: _radioStyleDark,
   primaryColorDark: yaru.Colors.orange,
   appBarTheme: _appBarDarkTheme,
   floatingActionButtonTheme: FloatingActionButtonThemeData(
     backgroundColor: yaru.Colors.green,
   ),
   bottomNavigationBarTheme: BottomNavigationBarThemeData(
-    selectedItemColor: _lightColorScheme.primary,
-    unselectedItemColor: _lightColorScheme.onSecondary.withOpacity(0.8),
+    selectedItemColor: _darkColorScheme.primary,
+    unselectedItemColor: yaru.Colors.warmGrey.shade300,
   ),
 );
 
-// Special casing some widgets
-// That are not catched with the default theming in flutter
-// "Green" elevated Buttons
+// Special casing some widgets to get the desired Yaru look
+// Buttons
+
+final _commonButtonStyle = ButtonStyle(visualDensity: VisualDensity.standard);
+
+final _buttonThemeData = ButtonThemeData(
+  shape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.circular(4.0),
+  ),
+);
+
+final _outlinedButtonThemeData = OutlinedButtonThemeData(
+    style: OutlinedButton.styleFrom(
+  visualDensity: _commonButtonStyle.visualDensity,
+  primary: yaru.Colors.textGrey,
+));
+
+final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
+    style: OutlinedButton.styleFrom(
+  visualDensity: _commonButtonStyle.visualDensity,
+  primary: Colors.white,
+));
+
+final _textButtonThemeData = TextButtonThemeData(
+    style:
+        TextButton.styleFrom(visualDensity: _commonButtonStyle.visualDensity));
+
 Color _getElevatedButtonColorLight(Set<MaterialState> states) {
   const Set<MaterialState> interactiveStates = <MaterialState>{
     MaterialState.pressed,
@@ -171,6 +156,15 @@ Color _getElevatedButtonColorLight(Set<MaterialState> states) {
   }
   return yaru.Colors.green;
 }
+
+final _elevatedButtonThemeDataLight = ElevatedButtonThemeData(
+  style: _commonButtonStyle.copyWith(
+    textStyle: MaterialStateProperty.all(_textTheme.button),
+    backgroundColor: MaterialStateProperty.resolveWith(
+      _getElevatedButtonColorLight,
+    ),
+  ),
+);
 
 Color _getElevatedButtonColorDark(Set<MaterialState> states) {
   const Set<MaterialState> interactiveStates = <MaterialState>{
@@ -189,15 +183,6 @@ Color _getElevatedButtonColorDark(Set<MaterialState> states) {
   return yaru.Colors.green;
 }
 
-final _elevatedButtonThemeData = ElevatedButtonThemeData(
-  style: _commonButtonStyle.copyWith(
-    textStyle: MaterialStateProperty.all(_textTheme.button),
-    backgroundColor: MaterialStateProperty.resolveWith(
-      _getElevatedButtonColorLight,
-    ),
-  ),
-);
-
 final _elevatedButtonThemeDataDark = ElevatedButtonThemeData(
   style: _commonButtonStyle.copyWith(
     textStyle: MaterialStateProperty.all(_textTheme.button),
@@ -210,7 +195,36 @@ final _elevatedButtonThemeDataDark = ElevatedButtonThemeData(
 // Switches
 Color _getSwitchThumbColorDark(Set<MaterialState> states) {
   if (states.contains(MaterialState.disabled)) {
-    return yaru.Colors.warmGrey;
+    return yaru.Colors.disabledGreyDark;
+  } else {
+    if (states.contains(MaterialState.selected)) {
+      return yaru.Colors.lightAubergine;
+    } else {
+      return yaru.Colors.warmGrey;
+    }
+  }
+}
+
+Color _getSwitchTrackColorDark(Set<MaterialState> states) {
+  if (states.contains(MaterialState.disabled)) {
+    return yaru.Colors.disabledGreyDark.withAlpha(120);
+  } else {
+    if (states.contains(MaterialState.selected)) {
+      return yaru.Colors.lightAubergine.withAlpha(160);
+    } else {
+      return yaru.Colors.warmGrey.withAlpha(80);
+    }
+  }
+}
+
+final _switchStyleDark = SwitchThemeData(
+  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
+  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
+);
+
+Color _getSwitchThumbColorLight(Set<MaterialState> states) {
+  if (states.contains(MaterialState.disabled)) {
+    return yaru.Colors.warmGrey.shade200;
   } else {
     if (states.contains(MaterialState.selected)) {
       return yaru.Colors.lightAubergine;
@@ -220,21 +234,21 @@ Color _getSwitchThumbColorDark(Set<MaterialState> states) {
   }
 }
 
-Color _getSwitchTrackColorDark(Set<MaterialState> states) {
+Color _getSwitchTrackColorLight(Set<MaterialState> states) {
   if (states.contains(MaterialState.disabled)) {
-    return yaru.Colors.disabledGreyDark;
+    return yaru.Colors.warmGrey.shade200;
   } else {
     if (states.contains(MaterialState.selected)) {
       return yaru.Colors.lightAubergine.withAlpha(180);
     } else {
-      return yaru.Colors.warmGrey;
+      return yaru.Colors.warmGrey.shade300;
     }
   }
 }
 
-final _switchStyleDark = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
+final _switchStyleLight = SwitchThemeData(
+  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
+  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
 );
 
 // Checks
@@ -255,13 +269,55 @@ Color _getCheckColorDark(Set<MaterialState> states) {
   return yaru.Colors.warmGrey;
 }
 
-final _checkStyle = CheckboxThemeData(
+final _checkStyleDark = CheckboxThemeData(
   fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
   checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
 );
 
+Color _getCheckFillColorLight(Set<MaterialState> states) {
+  if (!states.contains(MaterialState.disabled)) {
+    if (states.contains(MaterialState.selected)) {
+      return yaru.Colors.lightAubergine;
+    }
+    return yaru.Colors.warmGrey;
+  }
+  return yaru.Colors.warmGrey.shade300;
+}
+
+Color _getCheckColorLight(Set<MaterialState> states) {
+  if (!states.contains(MaterialState.disabled)) {
+    return Colors.white;
+  }
+  return yaru.Colors.warmGrey;
+}
+
+final _checkStyleLight = CheckboxThemeData(
+  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
+  checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
+);
+
 // Radios
-final _radioStyle = RadioThemeData(
+final _radioStyleDark = RadioThemeData(
     fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark));
 
-final _commonButtonStyle = ButtonStyle(visualDensity: VisualDensity.standard);
+final _radioStyleLight = RadioThemeData(
+    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight));
+
+final _appBarLightTheme = AppBarTheme(
+  brightness: Brightness.light,
+  color: yaru.Colors.porcelain,
+  textTheme: textTheme.copyWith(
+    headline6: textTheme.headline6!.copyWith(
+      color: yaru.Colors.coolGrey,
+      fontSize: 20,
+      fontWeight: FontWeight.w500,
+    ),
+  ),
+  iconTheme: IconThemeData(color: yaru.Colors.coolGrey),
+  actionsIconTheme: IconThemeData(color: yaru.Colors.coolGrey),
+);
+
+final _appBarDarkTheme = AppBarTheme(
+  brightness: Brightness.dark,
+  color: yaru.Colors.inkstone,
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaru
-version: 0.0.4
+version: 0.0.5
 
 description: Ubuntu Yaru Style - Distinct look and feel of the Ubuntu Desktop
 


### PR DESCRIPTION
* [Frederik Feichtmeier](https://github.com/Feichtmeier)
  * Reduce themes to 2 and update light/dark mode button (#63)
  * Fixes and improvements for Flutter 2.3 (#64)

![Bildschirmfoto von 2021-05-11 19-16-45](https://user-images.githubusercontent.com/15329494/117857983-ae56f780-b28d-11eb-9fbf-e72b6c0eca41.png)
![Bildschirmfoto von 2021-05-11 19-18-45](https://user-images.githubusercontent.com/15329494/117858031-bc0c7d00-b28d-11eb-8f81-f29b7327f490.png)

Closes #49 
