### PR TITLE
Update readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,25 @@ Ubuntu [Yaru](https://github.com/ubuntu/yaru) Style - Distinct look and feel of 
 ## Using Yaru
 To be able to use this package follow this steps:
 1. [Installation](https://pub.dev/packages/yaru/install)
-1. Make you sure when you import this package `as` yaru.
-1. Inside your `MaterialApp` you have to pass the `yaru.theme` which is the standard yaru theme.
-
-```dart
-MaterialApp(
-      theme: yaru.theme,
-      home: Scaffold(
-        appBar: AppBar(
-          title: Text('Yaru Theme'),
-        ),
-        body: Container(),
-      ),
-    );
-```
+1. Make you sure when you import this package `as` yaru
+   
+    ```dart
+    import 'package:yaru/yaru.dart' as yaru;
+    ```
+2. Inside your `MaterialApp` set `theme` to `yaru.lightTheme` which is the standard light theme and `darkTheme` to `yaru.darkTheme` to get the yaru dark theme. The `darkTheme` property is used when you toggle your system theme to dark:
+   
+    ```dart
+    MaterialApp(
+          theme: yaru.lightTheme,
+          darkTheme: yaru.darkTheme,
+          home: Scaffold(
+            appBar: AppBar(
+              title: Text('Yaru Theme'),
+            ),
+            body: Container(),
+          ),
+        );
+    ```
 
 ## Contributing to yaru.dart
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Ubuntu [Yaru](https://github.com/ubuntu/yaru) Style - Distinct look and feel of 
 ## Using Yaru
 To be able to use this package follow this steps:
 1. [Installation](https://pub.dev/packages/yaru/install)
-1. Make you sure when you import this package `as` yaru
+2. Make you sure when you import this package `as` yaru
    
     ```dart
     import 'package:yaru/yaru.dart' as yaru;
     ```
-2. Inside your `MaterialApp` set `theme` to `yaru.lightTheme` which is the standard light theme and `darkTheme` to `yaru.darkTheme` to get the yaru dark theme. The `darkTheme` property is used when you toggle your system theme to dark:
+3. Inside your `MaterialApp` set `theme` to `yaru.lightTheme` which is the standard light theme and `darkTheme` to `yaru.darkTheme` to get the yaru dark theme. The `darkTheme` property is used when you toggle your system theme to dark:
    
     ```dart
     MaterialApp(


### PR DESCRIPTION
Updated the readme instructions with the correct import command and with the new theme names (.theme no longer exists)

![grafik](https://user-images.githubusercontent.com/15329494/117959325-2ec43980-b31c-11eb-82fe-991dc216ba71.png)
