### PR TITLE
All TextFields should have a border in Yaru

### DIFF
--- a/example/lib/view/inputs_view.dart
+++ b/example/lib/view/inputs_view.dart
@@ -14,7 +14,9 @@ class InputsView extends StatelessWidget {
           const SizedBox(height: 15),
           TextField(
             autofocus: true,
-            decoration: InputDecoration(hintText: 'Awesome Textfield'),
+            decoration: InputDecoration(
+                hintText: 'Awesome Textfield',
+                labelText: 'All TextFields have a border in Yaru'),
           ),
           const SizedBox(height: 15),
           TextField(

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -41,38 +41,40 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 );
 
 final lightTheme = ThemeData(
-  brightness: Brightness.light,
-  primaryColor: _lightColorScheme.primary,
-  primaryColorBrightness:
-      ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
-  canvasColor: _lightColorScheme.background,
-  scaffoldBackgroundColor: _lightColorScheme.background,
-  bottomAppBarColor: _lightColorScheme.surface,
-  cardColor: _lightColorScheme.surface,
-  dividerColor: _lightColorScheme.onSurface.withOpacity(0.12),
-  backgroundColor: _lightColorScheme.background,
-  dialogBackgroundColor: _lightColorScheme.background,
-  errorColor: _lightColorScheme.error,
-  textTheme: _textTheme,
-  indicatorColor: _lightColorScheme.secondary,
-  applyElevationOverlayColor: false,
-  colorScheme: _lightColorScheme,
-  buttonTheme: _buttonThemeData,
-  elevatedButtonTheme: _getElevatedButtonThemeData(Brightness.light),
-  outlinedButtonTheme: _outlinedButtonThemeData,
-  textButtonTheme: _textButtonThemeData,
-  switchTheme: _switchStyleLight,
-  checkboxTheme: _checkStyleLight,
-  radioTheme: _radioStyleLight,
-  appBarTheme: _appBarLightTheme,
-  floatingActionButtonTheme: FloatingActionButtonThemeData(
-    backgroundColor: yaru.Colors.green,
-  ),
-  bottomNavigationBarTheme: BottomNavigationBarThemeData(
-    selectedItemColor: _lightColorScheme.primary,
-    unselectedItemColor: yaru.Colors.coolGrey,
-  ),
-);
+    brightness: Brightness.light,
+    primaryColor: _lightColorScheme.primary,
+    primaryColorBrightness:
+        ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
+    canvasColor: _lightColorScheme.background,
+    scaffoldBackgroundColor: _lightColorScheme.background,
+    bottomAppBarColor: _lightColorScheme.surface,
+    cardColor: _lightColorScheme.surface,
+    dividerColor: _lightColorScheme.onSurface.withOpacity(0.12),
+    backgroundColor: _lightColorScheme.background,
+    dialogBackgroundColor: _lightColorScheme.background,
+    errorColor: _lightColorScheme.error,
+    textTheme: _textTheme,
+    indicatorColor: _lightColorScheme.secondary,
+    applyElevationOverlayColor: false,
+    colorScheme: _lightColorScheme,
+    buttonTheme: _buttonThemeData,
+    elevatedButtonTheme: _getElevatedButtonThemeData(Brightness.light),
+    outlinedButtonTheme: _outlinedButtonThemeData,
+    textButtonTheme: _textButtonThemeData,
+    switchTheme: _switchStyleLight,
+    checkboxTheme: _checkStyleLight,
+    radioTheme: _radioStyleLight,
+    appBarTheme: _appBarLightTheme,
+    floatingActionButtonTheme: FloatingActionButtonThemeData(
+      backgroundColor: yaru.Colors.green,
+    ),
+    bottomNavigationBarTheme: BottomNavigationBarThemeData(
+      selectedItemColor: _lightColorScheme.primary,
+      unselectedItemColor: yaru.Colors.coolGrey,
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      border: OutlineInputBorder(),
+    ));
 
 final darkTheme = ThemeData(
   brightness: Brightness.dark,


### PR DESCRIPTION
As requested by @jpnurmi this gives textfield in yaru.dart always a border decoration

Before:
![grafik](https://user-images.githubusercontent.com/15329494/125625571-9a143ee9-7e57-4010-8472-686c2540abc2.png)


After:
![grafik](https://user-images.githubusercontent.com/15329494/125625511-2898ec3e-2ce0-4124-9248-6346fb3c7dde.png)

