### PR TITLE
Dark theme: Brighten up check and radios and adapt dark dialogs to gtk/shell theme

### DIFF
--- a/example/lib/view/controls_view.dart
+++ b/example/lib/view/controls_view.dart
@@ -147,6 +147,28 @@ class ControlsView extends StatelessWidget {
                 ),
               ],
             ),
+            Column(
+              children: [
+                Text('Checkbox'),
+                Row(
+                  children: [
+                    Checkbox(value: true, onChanged: (_) {}),
+                    Checkbox(value: false, onChanged: (_) {}),
+                    Checkbox(value: true, onChanged: null),
+                    Checkbox(value: false, onChanged: null),
+                  ],
+                ),
+                Text('Radio'),
+                Row(
+                  children: [
+                    Radio(value: true, groupValue: true, onChanged: (_) {}),
+                    Radio(value: false, groupValue: true, onChanged: (_) {}),
+                    Radio(value: true, groupValue: true, onChanged: null),
+                    Radio(value: false, groupValue: true, onChanged: null),
+                  ],
+                ),
+              ],
+            ),
           ],
         ),
         LinearProgressIndicator(),

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -78,6 +78,11 @@ final lightTheme = ThemeData(
     ));
 
 final darkTheme = ThemeData(
+  dialogTheme: DialogTheme(
+      backgroundColor: yaru.Colors.jet,
+      shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(6),
+          side: BorderSide(color: Colors.white.withOpacity(0.2)))),
   brightness: Brightness.dark,
   primaryColor: _darkColorScheme.primary,
   primaryColorBrightness:
@@ -236,7 +241,7 @@ Color _getCheckFillColorDark(Set<MaterialState> states) {
     if (states.contains(MaterialState.selected)) {
       return yaru.Colors.orange;
     }
-    return yaru.Colors.warmGrey;
+    return yaru.Colors.warmGrey.shade400;
   }
   return yaru.Colors.warmGrey.withOpacity(0.4);
 }

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -238,7 +238,7 @@ Color _getCheckFillColorDark(Set<MaterialState> states) {
     }
     return yaru.Colors.warmGrey;
   }
-  return yaru.Colors.disabledGreyDark;
+  return yaru.Colors.warmGrey.withOpacity(0.4);
 }
 
 Color _getCheckColorDark(Set<MaterialState> states) {

--- a/lib/src/utils/colors.dart
+++ b/lib/src/utils/colors.dart
@@ -90,5 +90,5 @@ class Colors {
   static const Color disabledGreyDark = Color(0xFF535353);
   static const Color porcelain = Color(0xFFF7F7F7);
   static const Color inkstone = Color(0xFF3B3B3B);
-  static const Color jet = Color(0xFF1D1D1D);
+  static const Color jet = Color(0xFF2B2B2B);
 }


### PR DESCRIPTION
they where invisible in dialogs. Also update the example to see checks and radios and the dialog style
![grafik](https://user-images.githubusercontent.com/15329494/134506340-deb8ae38-8078-47cc-a08a-8e38336753ad.png)
![grafik](https://user-images.githubusercontent.com/15329494/134506554-b8c9b91b-4506-4f1e-afdb-b9fb7c49790a.png)

Closes #93 