### PR TITLE
Make dark theme bg darker

### DIFF
--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -35,8 +35,8 @@ final _darkColorScheme = ColorScheme.fromSwatch(
   primarySwatch: _primarySwatchColor,
   primaryColorDark: yaru.Colors.coolGrey,
   accentColor: yaru.Colors.orange,
-  cardColor: yaru.Colors.coolGrey,
-  backgroundColor: yaru.Colors.coolGrey,
+  cardColor: yaru.Colors.jet,
+  backgroundColor: yaru.Colors.jet,
   errorColor: yaru.Colors.red,
   brightness: Brightness.dark,
 );
@@ -310,7 +310,7 @@ final _appBarLightTheme = AppBarTheme(
 final _appBarDarkTheme = AppBarTheme(
   elevation: 1.0,
   systemOverlayStyle: SystemUiOverlayStyle.dark,
-  backgroundColor: yaru.Colors.inkstone,
+  backgroundColor: yaru.Colors.jet,
   foregroundColor: yaru.Colors.porcelain,
   titleTextStyle: textTheme.headline6!.copyWith(
     color: yaru.Colors.porcelain,

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -79,7 +79,7 @@ final lightTheme = ThemeData(
 
 final darkTheme = ThemeData(
   dialogTheme: DialogTheme(
-      backgroundColor: yaru.Colors.jet,
+      backgroundColor: yaru.Colors.coolGrey,
       shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(6),
           side: BorderSide(color: Colors.white.withOpacity(0.2)))),


### PR DESCRIPTION
Use `jet` instead of `coolGrey` for background color and so have a closer look with Yaru Gtk theme.

**Before:**

![Capture d’écran du 2021-10-03 11-45-29](https://user-images.githubusercontent.com/36476595/135748460-b5ffab9c-a679-437f-841e-c60247ecfafa.png)

**After:**

![Capture d’écran du 2021-10-03 11-44-30](https://user-images.githubusercontent.com/36476595/135748465-3a80384f-bf16-4188-b185-6360c8214246.png)
