### PR TITLE
Add a tabbar theme and update example

### DIFF
--- a/example/lib/view/controls_view.dart
+++ b/example/lib/view/controls_view.dart
@@ -1,185 +1,221 @@
 import 'package:flutter/material.dart';
 
-class ControlsView extends StatelessWidget {
+class ControlsView extends StatefulWidget {
+  @override
+  State<ControlsView> createState() => _ControlsViewState();
+}
+
+class _ControlsViewState extends State<ControlsView>
+    with TickerProviderStateMixin {
+  late TabController tabController;
+
+  @override
+  void initState() {
+    tabController = TabController(length: 4, vsync: this);
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      padding: EdgeInsets.all(15.0),
-      children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Row(children: <Widget>[
-            TextButton(
-              onPressed: () => print('FlatButton'),
-              child: const Text('Click me!'),
-            ),
-            const SizedBox(width: 15),
-            TextButton(
-              onPressed: null,
-              child: const Text("Can't click me!"),
-              autofocus: true,
-            ),
-          ]),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Row(children: <Widget>[
-            OutlinedButton(
-              onPressed: () => print('OutlinedButton'),
-              child: const Text('Click me!'),
-            ),
-            const SizedBox(width: 15),
-            OutlinedButton(
-              onPressed: null,
-              child: const Text("Can't click me!"),
-            ),
-          ]),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Row(children: <Widget>[
-            ElevatedButton(
-              onPressed: () => print('RaisedButton'),
-              child: const Text('Click me!'),
-            ),
-            const SizedBox(width: 15),
-            ElevatedButton(
-              onPressed: null,
-              child: const Text("Can't click me!"),
-            ),
-          ]),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Row(
-            children: <Widget>[
-              DropdownButton<int>(
-                onChanged: (value) => print('DropdownButton $value'),
-                value: 1,
-                items: <DropdownMenuItem<int>>[
-                  DropdownMenuItem(value: 1, child: const Text('One')),
-                  DropdownMenuItem(value: 2, child: const Text('Two')),
-                  DropdownMenuItem(value: 3, child: const Text('Three')),
+    return Column(
+      children: [
+        TabBar(controller: tabController, tabs: [
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Text('Buttons'),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Text('Checks'),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Text('Switches'),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Text('Progress'),
+          )
+        ]),
+        Expanded(
+          child: TabBarView(
+            controller: tabController,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(children: <Widget>[
+                        SizedBox(
+                          width: 95,
+                          child: TextButton(
+                            onPressed: () => print('FlatButton'),
+                            child: const Text('Click me!'),
+                          ),
+                        ),
+                        const SizedBox(width: 15),
+                        TextButton(
+                          onPressed: null,
+                          child: const Text("Can't click me!"),
+                          autofocus: true,
+                        ),
+                      ]),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(children: <Widget>[
+                        OutlinedButton(
+                          onPressed: () => print('OutlinedButton'),
+                          child: const Text('Click me!'),
+                        ),
+                        const SizedBox(width: 15),
+                        OutlinedButton(
+                          onPressed: null,
+                          child: const Text("Can't click me!"),
+                        ),
+                      ]),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(children: <Widget>[
+                        ElevatedButton(
+                          onPressed: () => print('RaisedButton'),
+                          child: const Text('Click me!'),
+                        ),
+                        const SizedBox(width: 15),
+                        ElevatedButton(
+                          onPressed: null,
+                          child: const Text("Can't click me!"),
+                        ),
+                      ]),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(12.0),
+                      child: Row(
+                        children: <Widget>[
+                          DropdownButton<int>(
+                            onChanged: (value) =>
+                                print('DropdownButton $value'),
+                            value: 1,
+                            items: <DropdownMenuItem<int>>[
+                              DropdownMenuItem(
+                                  value: 1, child: const Text('One')),
+                              DropdownMenuItem(
+                                  value: 2, child: const Text('Two')),
+                              DropdownMenuItem(
+                                  value: 3, child: const Text('Three')),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              ListView(
+                shrinkWrap: true,
+                padding: EdgeInsets.all(15.0),
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      Column(
+                        children: [
+                          Text('Checkbox'),
+                          Row(
+                            children: [
+                              Checkbox(value: true, onChanged: (_) {}),
+                              Checkbox(value: false, onChanged: (_) {}),
+                              Checkbox(value: true, onChanged: null),
+                              Checkbox(value: false, onChanged: null),
+                            ],
+                          ),
+                          Text('Radio'),
+                          Row(
+                            children: [
+                              Radio(
+                                  value: true,
+                                  groupValue: true,
+                                  onChanged: (_) {}),
+                              Radio(
+                                  value: false,
+                                  groupValue: true,
+                                  onChanged: (_) {}),
+                              Radio(
+                                  value: true,
+                                  groupValue: true,
+                                  onChanged: null),
+                              Radio(
+                                  value: false,
+                                  groupValue: true,
+                                  onChanged: null),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 15),
+                ],
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Row(
+                      children: <Widget>[
+                        Switch(onChanged: (value) {}, value: true),
+                        const Text('Yes'),
+                      ],
+                    ),
+                    Row(
+                      children: <Widget>[
+                        Switch(onChanged: (value) {}, value: false),
+                        const Text('No'),
+                      ],
+                    ),
+                    Row(
+                      children: <Widget>[
+                        Switch(
+                          value: true,
+                          onChanged: null,
+                        ),
+                        const Text('Disabled Yes'),
+                      ],
+                    ),
+                    Row(
+                      children: <Widget>[
+                        Switch(
+                          value: false,
+                          onChanged: null,
+                        ),
+                        const Text('Disabled No'),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(18.0),
+                    child: Row(
+                      children: [
+                        CircularProgressIndicator(),
+                      ],
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(18.0),
+                    child: LinearProgressIndicator(),
+                  ),
                 ],
               ),
             ],
           ),
         ),
-        Row(
-          children: <Widget>[
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Row(
-                  children: <Widget>[
-                    Checkbox(onChanged: (value) {}, value: true),
-                    const Text('Yes'),
-                  ],
-                ),
-                Row(
-                  children: <Widget>[
-                    Checkbox(onChanged: (value) {}, value: false),
-                    const Text('No'),
-                  ],
-                ),
-                Row(
-                  children: <Widget>[
-                    Checkbox(
-                      value: true,
-                      onChanged: null,
-                    ),
-                    const Text('Disabled'),
-                  ],
-                ),
-              ],
-            ),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Row(
-                  children: <Widget>[
-                    Switch(onChanged: (value) {}, value: true),
-                    const Text('Yes'),
-                  ],
-                ),
-                Row(
-                  children: <Widget>[
-                    Switch(onChanged: (value) {}, value: false),
-                    const Text('No'),
-                  ],
-                ),
-                Row(
-                  children: <Widget>[
-                    Switch(
-                      value: true,
-                      onChanged: null,
-                    ),
-                    const Text('Disabled'),
-                  ],
-                ),
-              ],
-            ),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Row(
-                  children: <Widget>[
-                    Radio(onChanged: (value) {}, value: 1, groupValue: 1),
-                    const Text('Yes'),
-                  ],
-                ),
-                Row(
-                  children: <Widget>[
-                    Radio(onChanged: (value) {}, value: 2, groupValue: 1),
-                    const Text('No'),
-                  ],
-                ),
-                Row(
-                  children: <Widget>[
-                    Radio(
-                      value: 3,
-                      groupValue: 1,
-                      onChanged: null,
-                    ),
-                    const Text('Disabled'),
-                  ],
-                ),
-              ],
-            ),
-            Column(
-              children: [
-                Text('Checkbox'),
-                Row(
-                  children: [
-                    Checkbox(value: true, onChanged: (_) {}),
-                    Checkbox(value: false, onChanged: (_) {}),
-                    Checkbox(value: true, onChanged: null),
-                    Checkbox(value: false, onChanged: null),
-                  ],
-                ),
-                Text('Radio'),
-                Row(
-                  children: [
-                    Radio(value: true, groupValue: true, onChanged: (_) {}),
-                    Radio(value: false, groupValue: true, onChanged: (_) {}),
-                    Radio(value: true, groupValue: true, onChanged: null),
-                    Radio(value: false, groupValue: true, onChanged: null),
-                  ],
-                ),
-              ],
-            ),
-          ],
-        ),
-        LinearProgressIndicator(),
-        Padding(
-          padding: const EdgeInsets.all(18.0),
-          child: Row(
-            children: [
-              CircularProgressIndicator(),
-            ],
-          ),
-        ),
-        const SizedBox(height: 15),
       ],
     );
   }

--- a/example/linux/my_application.cc
+++ b/example/linux/my_application.cc
@@ -40,14 +40,19 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "yaru_test");
+    gtk_header_bar_set_title(header_bar, "Yaru Theme Widget Factory");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "yaru_test");
+    gtk_window_set_title(window, "Yaru Theme Widget Factory");
   }
 
-  gtk_window_set_default_size(window, 1280, 720);
+   GdkGeometry geometry;
+  geometry.min_width = 600;
+  geometry.min_height = 700;
+  gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
+
+  gtk_window_set_default_size(window, 600, 700);
   gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -42,6 +42,7 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 );
 
 final lightTheme = ThemeData(
+    tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
     brightness: Brightness.light,
     primaryColor: _lightColorScheme.primary,
     primaryColorBrightness:
@@ -78,6 +79,7 @@ final lightTheme = ThemeData(
     ));
 
 final darkTheme = ThemeData(
+  tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onBackground),
   dialogTheme: DialogTheme(
       backgroundColor: yaru.Colors.jet,
       shape: RoundedRectangleBorder(


### PR DESCRIPTION
- we did not theme the tabbar but we do theme the appbar which was making the tabbar have white text in the light theme. Adding a TabBarTheme fixes this
- Updated the example to visualise a TabBar and TabBarView and split the controls section
- Added a min size for the window to prevent squeezed tabbar
- Changed the title from "yaru_test" to "Yaru Theme Widget Factory"

![grafik](https://user-images.githubusercontent.com/15329494/140513804-954a0d7c-ff31-4f61-8236-9acca62167cb.png)



Closes #102 