### PR TITLE
Dense tiles and inputs, updated Example

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: subosito/flutter-action@v1
       with:
-        channel: 'dev'
+        channel: 'stable'
 
     - name: Enable Linux desktop support
       run: flutter config --enable-linux-desktop

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,10 +18,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Yaru Example',
-      theme: theme.copyWith(
-          visualDensity: VisualDensity.adaptivePlatformDensity,
-          listTileTheme: ListTileThemeData(dense: true),
-          buttonTheme: ButtonThemeData(height: 100)),
+      theme: theme,
       home: HomePage(
           themeChanged: (themeName) => setState(() {
                 if (themeName == 'Yaru-light') {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,7 +18,10 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Yaru Example',
-      theme: theme,
+      theme: theme.copyWith(
+          visualDensity: VisualDensity.adaptivePlatformDensity,
+          listTileTheme: ListTileThemeData(dense: true),
+          buttonTheme: ButtonThemeData(height: 100)),
       home: HomePage(
           themeChanged: (themeName) => setState(() {
                 if (themeName == 'Yaru-light') {

--- a/example/lib/view/home_page.dart
+++ b/example/lib/view/home_page.dart
@@ -3,6 +3,7 @@ import 'package:yaru_example/view/colors_view.dart';
 import 'package:yaru_example/view/controls_view.dart';
 import 'package:yaru_example/view/fonts_view.dart';
 import 'package:yaru_example/view/inputs_view.dart';
+import 'package:yaru_example/view/lists_view.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key, required this.themeChanged}) : super(key: key);
@@ -36,7 +37,8 @@ class _HomePageState extends State<HomePage> {
     FontsView(),
     ControlsView(),
     InputsView(),
-    ColorsView()
+    ColorsView(),
+    ListsView(),
   ];
 
   Widget build(BuildContext context) {
@@ -83,7 +85,11 @@ class _HomePageState extends State<HomePage> {
               BottomNavigationBarItem(
                   icon: Icon(Icons.color_lens_outlined),
                   activeIcon: Icon(Icons.color_lens),
-                  label: 'Palette')
+                  label: 'Palette'),
+              BottomNavigationBarItem(
+                  icon: Icon(Icons.list_outlined),
+                  activeIcon: Icon(Icons.list),
+                  label: 'Lists')
             ],
             currentIndex: _selectedIndex,
             onTap: (index) => setState(() => _selectedIndex = index),

--- a/example/lib/view/lists_view.dart
+++ b/example/lib/view/lists_view.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 class ListsView extends StatefulWidget {
@@ -7,11 +9,69 @@ class ListsView extends StatefulWidget {
   State<ListsView> createState() => _ListsViewState();
 }
 
-class _ListsViewState extends State<ListsView> {
+class _ListsViewState extends State<ListsView> with TickerProviderStateMixin {
+  late TabController tabController;
   int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    tabController = TabController(length: 2, vsync: this);
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
-    List<String> items = List.generate(301, (index) => 'Item $index');
+    return Column(
+      children: [
+        TabBar(controller: tabController, tabs: [
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Text('ListView'),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Text('Table'),
+          ),
+        ]),
+        Expanded(
+            child: TabBarView(
+          controller: tabController,
+          children: [generateListView(), generateTable(context)],
+        ))
+      ],
+    );
+  }
+
+  Container generateTable(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(20.0),
+      child: Table(
+        // defaultColumnWidth: FixedColumnWidth(150),
+        border: TableBorder.all(color: Theme.of(context).disabledColor),
+        children: [
+          TableRow(
+            children: [
+              for (var i = 0; i < 3; i++)
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text('Cell ${i + 1}'),
+                )
+            ],
+          ),
+          TableRow(children: [
+            for (var i = 3; i < 6; i++)
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text('Cell ${i + 1}'),
+              )
+          ])
+        ],
+      ),
+    );
+  }
+
+  ListView generateListView() {
+    final items = List.generate(300, (index) => 'Item ${index + 1}');
 
     return ListView.builder(
       itemBuilder: (context, index) {

--- a/example/lib/view/lists_view.dart
+++ b/example/lib/view/lists_view.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 
 class ListsView extends StatefulWidget {

--- a/example/lib/view/lists_view.dart
+++ b/example/lib/view/lists_view.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class ListsView extends StatefulWidget {
+  const ListsView({Key? key}) : super(key: key);
+
+  @override
+  State<ListsView> createState() => _ListsViewState();
+}
+
+class _ListsViewState extends State<ListsView> {
+  int _selectedIndex = 0;
+  @override
+  Widget build(BuildContext context) {
+    List<String> items = List.generate(301, (index) => 'Item $index');
+
+    return ListView.builder(
+      itemBuilder: (context, index) {
+        return ListTile(
+          selected: index == _selectedIndex,
+          onTap: () {
+            setState(() {
+              _selectedIndex = index;
+            });
+          },
+          title: Text(items[index]),
+        );
+      },
+      itemCount: items.length,
+    );
+  }
+
+  void select() {}
+}

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -83,3 +83,8 @@ double _getElevation(Set<MaterialState> states) {
 }
 
 final listTileTheme = ListTileThemeData(dense: true);
+
+final inputDecorationTheme = InputDecorationTheme(
+  isDense: true,
+  border: OutlineInputBorder(),
+);

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -81,3 +81,5 @@ double _getElevation(Set<MaterialState> states) {
   }
   return 0.0;
 }
+
+final listTileTheme = ListTileThemeData(dense: true);

--- a/lib/src/themes/yaru_dark.dart
+++ b/lib/src/themes/yaru_dark.dart
@@ -55,9 +55,7 @@ final yaruDark = ThemeData(
       selectedItemColor: _darkColorScheme.primary,
       unselectedItemColor: YaruColors.warmGrey.shade300,
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      border: OutlineInputBorder(),
-    ),
+    inputDecorationTheme: inputDecorationTheme,
     listTileTheme: listTileTheme);
 
 final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(

--- a/lib/src/themes/yaru_dark.dart
+++ b/lib/src/themes/yaru_dark.dart
@@ -16,49 +16,49 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 );
 
 final yaruDark = ThemeData(
-  tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onBackground),
-  dialogTheme: DialogTheme(
-      backgroundColor: YaruColors.coolGrey,
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-          side: BorderSide(color: Colors.white.withOpacity(0.2)))),
-  brightness: Brightness.dark,
-  primaryColor: _darkColorScheme.primary,
-  primaryColorBrightness:
-      ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
-  canvasColor: _darkColorScheme.background,
-  scaffoldBackgroundColor: _darkColorScheme.background,
-  bottomAppBarColor: _darkColorScheme.surface,
-  cardColor: _darkColorScheme.surface,
-  dividerColor: _darkColorScheme.onSurface.withOpacity(0.12),
-  backgroundColor: _darkColorScheme.background,
-  dialogBackgroundColor: _darkColorScheme.background,
-  errorColor: _darkColorScheme.error,
-  textTheme: textTheme,
-  indicatorColor: _darkColorScheme.secondary,
-  applyElevationOverlayColor: true,
-  colorScheme: _darkColorScheme,
-  buttonTheme: buttonThemeData,
-  textButtonTheme: textButtonThemeData,
-  elevatedButtonTheme:
-      getElevatedButtonThemeData(Brightness.dark, YaruColors.green),
-  outlinedButtonTheme: _darkOutlinedButtonThemeData,
-  switchTheme: _switchStyleDark,
-  checkboxTheme: _checkStyleDark,
-  radioTheme: _radioStyleDark,
-  primaryColorDark: _primaryColor,
-  appBarTheme: appBarDarkTheme,
-  floatingActionButtonTheme: FloatingActionButtonThemeData(
-    backgroundColor: YaruColors.green,
-  ),
-  bottomNavigationBarTheme: BottomNavigationBarThemeData(
-    selectedItemColor: _darkColorScheme.primary,
-    unselectedItemColor: YaruColors.warmGrey.shade300,
-  ),
-  inputDecorationTheme: InputDecorationTheme(
-    border: OutlineInputBorder(),
-  ),
-);
+    tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onBackground),
+    dialogTheme: DialogTheme(
+        backgroundColor: YaruColors.coolGrey,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(6),
+            side: BorderSide(color: Colors.white.withOpacity(0.2)))),
+    brightness: Brightness.dark,
+    primaryColor: _darkColorScheme.primary,
+    primaryColorBrightness:
+        ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
+    canvasColor: _darkColorScheme.background,
+    scaffoldBackgroundColor: _darkColorScheme.background,
+    bottomAppBarColor: _darkColorScheme.surface,
+    cardColor: _darkColorScheme.surface,
+    dividerColor: _darkColorScheme.onSurface.withOpacity(0.12),
+    backgroundColor: _darkColorScheme.background,
+    dialogBackgroundColor: _darkColorScheme.background,
+    errorColor: _darkColorScheme.error,
+    textTheme: textTheme,
+    indicatorColor: _darkColorScheme.secondary,
+    applyElevationOverlayColor: true,
+    colorScheme: _darkColorScheme,
+    buttonTheme: buttonThemeData,
+    textButtonTheme: textButtonThemeData,
+    elevatedButtonTheme:
+        getElevatedButtonThemeData(Brightness.dark, YaruColors.green),
+    outlinedButtonTheme: _darkOutlinedButtonThemeData,
+    switchTheme: _switchStyleDark,
+    checkboxTheme: _checkStyleDark,
+    radioTheme: _radioStyleDark,
+    primaryColorDark: _primaryColor,
+    appBarTheme: appBarDarkTheme,
+    floatingActionButtonTheme: FloatingActionButtonThemeData(
+      backgroundColor: YaruColors.green,
+    ),
+    bottomNavigationBarTheme: BottomNavigationBarThemeData(
+      selectedItemColor: _darkColorScheme.primary,
+      unselectedItemColor: YaruColors.warmGrey.shade300,
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      border: OutlineInputBorder(),
+    ),
+    listTileTheme: listTileTheme);
 
 final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(

--- a/lib/src/themes/yaru_kubuntu_dark.dart
+++ b/lib/src/themes/yaru_kubuntu_dark.dart
@@ -56,9 +56,7 @@ final yaruKubuntuDark = ThemeData(
     selectedItemColor: _darkColorScheme.primary,
     unselectedItemColor: YaruColors.warmGrey.shade300,
   ),
-  inputDecorationTheme: InputDecorationTheme(
-    border: OutlineInputBorder(),
-  ),
+  inputDecorationTheme: inputDecorationTheme,
 );
 
 final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(

--- a/lib/src/themes/yaru_kubuntu_light.dart
+++ b/lib/src/themes/yaru_kubuntu_light.dart
@@ -50,9 +50,7 @@ final yaruKubuntuLight = ThemeData(
       selectedItemColor: _lightColorScheme.primary,
       unselectedItemColor: YaruColors.coolGrey,
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      border: OutlineInputBorder(),
-    ));
+    inputDecorationTheme: inputDecorationTheme);
 
 Color _getSwitchThumbColorLight(Set<MaterialState> states) {
   if (states.contains(MaterialState.disabled)) {

--- a/lib/src/themes/yaru_light.dart
+++ b/lib/src/themes/yaru_light.dart
@@ -51,7 +51,8 @@ final yaruLight = ThemeData(
     ),
     inputDecorationTheme: InputDecorationTheme(
       border: OutlineInputBorder(),
-    ));
+    ),
+    listTileTheme: listTileTheme);
 
 Color _getSwitchThumbColorLight(Set<MaterialState> states) {
   if (states.contains(MaterialState.disabled)) {

--- a/lib/src/themes/yaru_light.dart
+++ b/lib/src/themes/yaru_light.dart
@@ -49,9 +49,7 @@ final yaruLight = ThemeData(
       selectedItemColor: _lightColorScheme.primary,
       unselectedItemColor: YaruColors.coolGrey,
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      border: OutlineInputBorder(),
-    ),
+    inputDecorationTheme: inputDecorationTheme,
     listTileTheme: listTileTheme);
 
 Color _getSwitchThumbColorLight(Set<MaterialState> states) {

--- a/lib/src/themes/yaru_lubuntu_dark.dart
+++ b/lib/src/themes/yaru_lubuntu_dark.dart
@@ -56,9 +56,7 @@ final yaruLubuntuDark = ThemeData(
     selectedItemColor: _darkColorScheme.primary,
     unselectedItemColor: YaruColors.warmGrey.shade300,
   ),
-  inputDecorationTheme: InputDecorationTheme(
-    border: OutlineInputBorder(),
-  ),
+  inputDecorationTheme: inputDecorationTheme,
 );
 
 final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(

--- a/lib/src/themes/yaru_lubuntu_light.dart
+++ b/lib/src/themes/yaru_lubuntu_light.dart
@@ -50,9 +50,7 @@ final yaruLubuntuLight = ThemeData(
       selectedItemColor: _lightColorScheme.primary,
       unselectedItemColor: YaruColors.coolGrey,
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      border: OutlineInputBorder(),
-    ));
+    inputDecorationTheme: inputDecorationTheme);
 
 Color _getSwitchThumbColorLight(Set<MaterialState> states) {
   if (states.contains(MaterialState.disabled)) {

--- a/lib/src/themes/yaru_mate_dark.dart
+++ b/lib/src/themes/yaru_mate_dark.dart
@@ -56,9 +56,7 @@ final yaruMateDark = ThemeData(
     selectedItemColor: _darkColorScheme.primary,
     unselectedItemColor: YaruColors.warmGrey.shade300,
   ),
-  inputDecorationTheme: InputDecorationTheme(
-    border: OutlineInputBorder(),
-  ),
+  inputDecorationTheme: inputDecorationTheme,
 );
 
 final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(

--- a/lib/src/themes/yaru_mate_light.dart
+++ b/lib/src/themes/yaru_mate_light.dart
@@ -50,9 +50,7 @@ final yaruMateLight = ThemeData(
       selectedItemColor: _lightColorScheme.primary,
       unselectedItemColor: YaruColors.coolGrey,
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      border: OutlineInputBorder(),
-    ));
+    inputDecorationTheme: inputDecorationTheme);
 
 Color _getSwitchThumbColorLight(Set<MaterialState> states) {
   if (states.contains(MaterialState.disabled)) {

--- a/lib/src/themes/yaru_ubuntu_budgie_dark.dart
+++ b/lib/src/themes/yaru_ubuntu_budgie_dark.dart
@@ -56,9 +56,7 @@ final yaruUbuntuBudgieDark = ThemeData(
     selectedItemColor: _darkColorScheme.primary,
     unselectedItemColor: YaruColors.warmGrey.shade300,
   ),
-  inputDecorationTheme: InputDecorationTheme(
-    border: OutlineInputBorder(),
-  ),
+  inputDecorationTheme: inputDecorationTheme,
 );
 
 final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(

--- a/lib/src/themes/yaru_ubuntu_budgie_light.dart
+++ b/lib/src/themes/yaru_ubuntu_budgie_light.dart
@@ -50,9 +50,7 @@ final yaruUbuntuBudgieLight = ThemeData(
       selectedItemColor: _lightColorScheme.primary,
       unselectedItemColor: YaruColors.coolGrey,
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      border: OutlineInputBorder(),
-    ));
+    inputDecorationTheme: inputDecorationTheme);
 
 Color _getSwitchThumbColorLight(Set<MaterialState> states) {
   if (states.contains(MaterialState.disabled)) {

--- a/lib/src/themes/yaru_ubuntu_studio_dark.dart
+++ b/lib/src/themes/yaru_ubuntu_studio_dark.dart
@@ -56,9 +56,7 @@ final yaruUbuntuStudioDark = ThemeData(
     selectedItemColor: _darkColorScheme.primary,
     unselectedItemColor: YaruColors.warmGrey.shade300,
   ),
-  inputDecorationTheme: InputDecorationTheme(
-    border: OutlineInputBorder(),
-  ),
+  inputDecorationTheme: inputDecorationTheme,
 );
 
 final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(

--- a/lib/src/themes/yaru_ubuntu_studio_light.dart
+++ b/lib/src/themes/yaru_ubuntu_studio_light.dart
@@ -50,9 +50,7 @@ final yaruUbuntuStudioLight = ThemeData(
       selectedItemColor: _lightColorScheme.primary,
       unselectedItemColor: YaruColors.coolGrey,
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      border: OutlineInputBorder(),
-    ));
+    inputDecorationTheme: inputDecorationTheme);
 
 Color _getSwitchThumbColorLight(Set<MaterialState> states) {
   if (states.contains(MaterialState.disabled)) {

--- a/lib/src/themes/yaru_xubuntu_dark.dart
+++ b/lib/src/themes/yaru_xubuntu_dark.dart
@@ -56,9 +56,7 @@ final yaruXubuntuDark = ThemeData(
     selectedItemColor: FlavorColors.xubuntuBlue.shade300,
     unselectedItemColor: YaruColors.warmGrey.shade300,
   ),
-  inputDecorationTheme: InputDecorationTheme(
-    border: OutlineInputBorder(),
-  ),
+  inputDecorationTheme: inputDecorationTheme,
 );
 
 final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(

--- a/lib/src/themes/yaru_xubuntu_light.dart
+++ b/lib/src/themes/yaru_xubuntu_light.dart
@@ -50,9 +50,7 @@ final yaruXubuntuLight = ThemeData(
       selectedItemColor: _lightColorScheme.primary,
       unselectedItemColor: YaruColors.coolGrey,
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      border: OutlineInputBorder(),
-    ));
+    inputDecorationTheme: inputDecorationTheme);
 
 Color _getSwitchThumbColorLight(Set<MaterialState> states) {
   if (states.contains(MaterialState.disabled)) {


### PR DESCRIPTION
List tiles and inputs were to fat compared to buttons. This PR makes them dense.

~~Todo:~~

~~- [ ] adapt table theme~~
Note: there is no general table style
Note: buttons have NO change on purpose, they need to stay big

| Widget | Before  | After |
| ------------- | ------------- | ------------- |
| Buttons | ![grafik](https://user-images.githubusercontent.com/15329494/145539557-93d93a3c-eef7-4160-b225-3a74e9803ec3.png)  | ![grafik](https://user-images.githubusercontent.com/15329494/145539557-93d93a3c-eef7-4160-b225-3a74e9803ec3.png)  |
| Inputs | ![grafik](https://user-images.githubusercontent.com/15329494/145540934-e0eea670-ee85-4f43-8772-608fa2ccc9de.png) | ![grafik](https://user-images.githubusercontent.com/15329494/145539708-bbf60ee5-1965-41f8-8d06-c4e8afaaf031.png) |
| ListTiles | ![grafik](https://user-images.githubusercontent.com/15329494/145540140-9cc56552-5221-4a57-8832-f1eab523f35d.png) | ![grafik](https://user-images.githubusercontent.com/15329494/145540215-06782b1a-aa26-4412-a850-8813c4e5de5c.png) |






CC @jpnurmi 
ref #116 
ref https://github.com/canonical/ubuntu-desktop-installer/issues/546