### PR TITLE
Consolidate theming in common_themes

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -2,11 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:yaru/src/text/text_theme.dart';
 import 'package:yaru/src/colors/yaru_colors.dart';
+import 'package:yaru/src/themes/constants.dart';
 
-const _appBarElevation = 1.0;
+// AppBar
 
 final appBarLightTheme = AppBarTheme(
-  elevation: _appBarElevation,
+  elevation: appBarElevation,
   systemOverlayStyle: SystemUiOverlayStyle.light,
   backgroundColor: YaruColors.porcelain,
   foregroundColor: YaruColors.coolGrey,
@@ -19,7 +20,7 @@ final appBarLightTheme = AppBarTheme(
 );
 
 final appBarDarkTheme = AppBarTheme(
-  elevation: _appBarElevation,
+  elevation: appBarElevation,
   systemOverlayStyle: SystemUiOverlayStyle.dark,
   backgroundColor: YaruColors.jet,
   foregroundColor: YaruColors.porcelain,
@@ -29,11 +30,13 @@ final appBarDarkTheme = AppBarTheme(
   ),
 );
 
+// Buttons
+
 final commonButtonStyle = ButtonStyle(visualDensity: VisualDensity.standard);
 
 final buttonThemeData = ButtonThemeData(
   shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(4.0),
+    borderRadius: BorderRadius.circular(buttonRadius),
   ),
 );
 
@@ -80,4 +83,98 @@ double _getElevation(Set<MaterialState> states) {
     return 2.0;
   }
   return 0.0;
+}
+
+// Dialogs
+
+final dialogThemeDark = DialogTheme(
+    backgroundColor: YaruColors.coolGrey,
+    shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(windowRadius),
+        side: BorderSide(color: Colors.white.withOpacity(0.2))));
+
+// Switches
+SwitchThemeData getSwitchThemeData(
+    MaterialColor primaryColor, Brightness brightness) {
+  return SwitchThemeData(
+      thumbColor: MaterialStateProperty.resolveWith(
+          (states) => _getSwitchThumbColor(states, primaryColor, brightness)),
+      trackColor: MaterialStateProperty.resolveWith(
+          (states) => _getSwitchTrackColor(states, primaryColor, brightness)));
+}
+
+Color _getSwitchThumbColor(Set<MaterialState> states,
+    MaterialColor selectedColor, Brightness brightness) {
+  if (states.contains(MaterialState.disabled)) {
+    return brightness == Brightness.dark
+        ? YaruColors.disabledGreyDark
+        : YaruColors.warmGrey.shade200;
+  } else {
+    if (states.contains(MaterialState.selected)) {
+      return selectedColor;
+    } else {
+      return brightness == Brightness.dark ? YaruColors.warmGrey : Colors.white;
+    }
+  }
+}
+
+Color _getSwitchTrackColor(Set<MaterialState> states,
+    MaterialColor selectedColor, Brightness brightness) {
+  if (states.contains(MaterialState.disabled)) {
+    return brightness == Brightness.dark
+        ? YaruColors.disabledGreyDark.withAlpha(120)
+        : YaruColors.warmGrey.shade200;
+  } else {
+    if (states.contains(MaterialState.selected)) {
+      return brightness == Brightness.dark
+          ? selectedColor.withAlpha(160)
+          : selectedColor.withAlpha(180);
+    } else {
+      return brightness == Brightness.dark
+          ? YaruColors.warmGrey.withAlpha(80)
+          : YaruColors.warmGrey.shade300;
+    }
+  }
+}
+
+// Checks
+Color _getCheckFillColorDark(Set<MaterialState> states,
+    MaterialColor selectedColor, Brightness brightness) {
+  if (!states.contains(MaterialState.disabled)) {
+    if (states.contains(MaterialState.selected)) {
+      return selectedColor;
+    }
+    return brightness == Brightness.dark
+        ? YaruColors.warmGrey.shade400
+        : YaruColors.warmGrey;
+  }
+  return brightness == Brightness.dark
+      ? YaruColors.warmGrey.withOpacity(0.4)
+      : YaruColors.warmGrey.shade300;
+}
+
+Color _getCheckColorDark(Set<MaterialState> states) {
+  if (!states.contains(MaterialState.disabled)) {
+    return Colors.white;
+  }
+  return YaruColors.warmGrey;
+}
+
+CheckboxThemeData getCheckBoxThemeDataDark(
+    MaterialColor primaryColor, Brightness brightness) {
+  return CheckboxThemeData(
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(checkRadius),
+    ),
+    fillColor: MaterialStateProperty.resolveWith(
+        (states) => _getCheckFillColorDark(states, primaryColor, brightness)),
+    checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
+  );
+}
+
+RadioThemeData getRadioThemeDataDark(
+    MaterialColor primaryColor, Brightness brightness) {
+  return RadioThemeData(
+      fillColor: MaterialStateProperty.resolveWith((states) =>
+          _getCheckFillColorDark(states, primaryColor, brightness)));
 }

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -1,0 +1,4 @@
+const buttonRadius = 4.0;
+const checkRadius = 2.0;
+const windowRadius = 6.0;
+const appBarElevation = 1.0;

--- a/lib/src/themes/yaru_dark.dart
+++ b/lib/src/themes/yaru_dark.dart
@@ -17,15 +17,9 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 
 final yaruDark = ThemeData(
   tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onBackground),
-  dialogTheme: DialogTheme(
-      backgroundColor: YaruColors.coolGrey,
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-          side: BorderSide(color: Colors.white.withOpacity(0.2)))),
+  dialogTheme: dialogThemeDark,
   brightness: Brightness.dark,
   primaryColor: _darkColorScheme.primary,
-  primaryColorBrightness:
-      ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
   canvasColor: _darkColorScheme.background,
   scaffoldBackgroundColor: _darkColorScheme.background,
   bottomAppBarColor: _darkColorScheme.surface,
@@ -42,10 +36,10 @@ final yaruDark = ThemeData(
   textButtonTheme: textButtonThemeData,
   elevatedButtonTheme:
       getElevatedButtonThemeData(Brightness.dark, YaruColors.green),
-  outlinedButtonTheme: _darkOutlinedButtonThemeData,
-  switchTheme: _switchStyleDark,
-  checkboxTheme: _checkStyleDark,
-  radioTheme: _radioStyleDark,
+  outlinedButtonTheme: darkOutlinedButtonThemeData,
+  switchTheme: getSwitchThemeData(_primaryColor, Brightness.dark),
+  checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.dark),
+  radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.dark),
   primaryColorDark: _primaryColor,
   appBarTheme: appBarDarkTheme,
   floatingActionButtonTheme: FloatingActionButtonThemeData(
@@ -59,67 +53,3 @@ final yaruDark = ThemeData(
     border: OutlineInputBorder(),
   ),
 );
-
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
-    style: OutlinedButton.styleFrom(
-  visualDensity: commonButtonStyle.visualDensity,
-  primary: Colors.white,
-));
-
-// Switches
-Color _getSwitchThumbColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return YaruColors.warmGrey;
-    }
-  }
-}
-
-Color _getSwitchTrackColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark.withAlpha(120);
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(160);
-    } else {
-      return YaruColors.warmGrey.withAlpha(80);
-    }
-  }
-}
-
-final _switchStyleDark = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
-);
-
-Color _getCheckFillColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey.shade400;
-  }
-  return YaruColors.warmGrey.withOpacity(0.4);
-}
-
-Color _getCheckColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleDark = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
-);
-
-final _radioStyleDark = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark));

--- a/lib/src/themes/yaru_kubuntu_dark.dart
+++ b/lib/src/themes/yaru_kubuntu_dark.dart
@@ -18,15 +18,9 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 
 final yaruKubuntuDark = ThemeData(
   tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onSurface),
-  dialogTheme: DialogTheme(
-      backgroundColor: YaruColors.coolGrey,
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-          side: BorderSide(color: Colors.white.withOpacity(0.2)))),
+  dialogTheme: dialogThemeDark,
   brightness: Brightness.dark,
   primaryColor: _darkColorScheme.primary,
-  primaryColorBrightness:
-      ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
   canvasColor: _darkColorScheme.background,
   scaffoldBackgroundColor: _darkColorScheme.background,
   bottomAppBarColor: _darkColorScheme.surface,
@@ -43,10 +37,10 @@ final yaruKubuntuDark = ThemeData(
   textButtonTheme: textButtonThemeData,
   elevatedButtonTheme:
       getElevatedButtonThemeData(Brightness.dark, _primaryColor),
-  outlinedButtonTheme: _darkOutlinedButtonThemeData,
-  switchTheme: _switchStyleDark,
-  checkboxTheme: _checkStyleDark,
-  radioTheme: _radioStyleDark,
+  outlinedButtonTheme: darkOutlinedButtonThemeData,
+  switchTheme: getSwitchThemeData(_primaryColor, Brightness.dark),
+  checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.dark),
+  radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.dark),
   primaryColorDark: _primaryColor,
   appBarTheme: appBarDarkTheme,
   floatingActionButtonTheme: FloatingActionButtonThemeData(
@@ -60,67 +54,3 @@ final yaruKubuntuDark = ThemeData(
     border: OutlineInputBorder(),
   ),
 );
-
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
-    style: OutlinedButton.styleFrom(
-  visualDensity: commonButtonStyle.visualDensity,
-  primary: Colors.white,
-));
-
-// Switches
-Color _getSwitchThumbColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return YaruColors.warmGrey;
-    }
-  }
-}
-
-Color _getSwitchTrackColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark.withAlpha(120);
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(160);
-    } else {
-      return YaruColors.warmGrey.withAlpha(80);
-    }
-  }
-}
-
-final _switchStyleDark = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
-);
-
-Color _getCheckFillColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey.shade400;
-  }
-  return YaruColors.warmGrey.withOpacity(0.4);
-}
-
-Color _getCheckColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleDark = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
-);
-
-final _radioStyleDark = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark));

--- a/lib/src/themes/yaru_kubuntu_light.dart
+++ b/lib/src/themes/yaru_kubuntu_light.dart
@@ -20,8 +20,6 @@ final yaruKubuntuLight = ThemeData(
     tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
     brightness: Brightness.light,
     primaryColor: _lightColorScheme.primary,
-    primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
     canvasColor: _lightColorScheme.background,
     scaffoldBackgroundColor: _lightColorScheme.background,
     bottomAppBarColor: _lightColorScheme.surface,
@@ -39,9 +37,9 @@ final yaruKubuntuLight = ThemeData(
     elevatedButtonTheme:
         getElevatedButtonThemeData(Brightness.light, _primaryColor),
     textButtonTheme: textButtonThemeData,
-    switchTheme: _switchStyleLight,
-    checkboxTheme: _checkStyleLight,
-    radioTheme: _radioStyleLight,
+    switchTheme: getSwitchThemeData(_primaryColor, Brightness.light),
+    checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.light),
+    radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.light),
     appBarTheme: appBarLightTheme,
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: _primaryColor,
@@ -53,60 +51,3 @@ final yaruKubuntuLight = ThemeData(
     inputDecorationTheme: InputDecorationTheme(
       border: OutlineInputBorder(),
     ));
-
-Color _getSwitchThumbColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return Colors.white;
-    }
-  }
-}
-
-Color _getSwitchTrackColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(180);
-    } else {
-      return YaruColors.warmGrey.shade300;
-    }
-  }
-}
-
-final _switchStyleLight = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
-);
-
-Color _getCheckFillColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey;
-  }
-  return YaruColors.warmGrey.shade300;
-}
-
-Color _getCheckColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleLight = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
-);
-
-final _radioStyleLight = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight));

--- a/lib/src/themes/yaru_light.dart
+++ b/lib/src/themes/yaru_light.dart
@@ -19,8 +19,6 @@ final yaruLight = ThemeData(
     tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
     brightness: Brightness.light,
     primaryColor: _lightColorScheme.primary,
-    primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
     canvasColor: _lightColorScheme.background,
     scaffoldBackgroundColor: _lightColorScheme.background,
     bottomAppBarColor: _lightColorScheme.surface,
@@ -38,9 +36,9 @@ final yaruLight = ThemeData(
     elevatedButtonTheme:
         getElevatedButtonThemeData(Brightness.light, YaruColors.green),
     textButtonTheme: textButtonThemeData,
-    switchTheme: _switchStyleLight,
-    checkboxTheme: _checkStyleLight,
-    radioTheme: _radioStyleLight,
+    switchTheme: getSwitchThemeData(_primaryColor, Brightness.light),
+    checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.light),
+    radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.light),
     appBarTheme: appBarLightTheme,
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: YaruColors.green,
@@ -52,60 +50,3 @@ final yaruLight = ThemeData(
     inputDecorationTheme: InputDecorationTheme(
       border: OutlineInputBorder(),
     ));
-
-Color _getSwitchThumbColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return Colors.white;
-    }
-  }
-}
-
-Color _getSwitchTrackColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(180);
-    } else {
-      return YaruColors.warmGrey.shade300;
-    }
-  }
-}
-
-final _switchStyleLight = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
-);
-
-Color _getCheckFillColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey;
-  }
-  return YaruColors.warmGrey.shade300;
-}
-
-Color _getCheckColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleLight = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
-);
-
-final _radioStyleLight = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight));

--- a/lib/src/themes/yaru_lubuntu_dark.dart
+++ b/lib/src/themes/yaru_lubuntu_dark.dart
@@ -18,15 +18,9 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 
 final yaruLubuntuDark = ThemeData(
   tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onSurface),
-  dialogTheme: DialogTheme(
-      backgroundColor: YaruColors.coolGrey,
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-          side: BorderSide(color: Colors.white.withOpacity(0.2)))),
+  dialogTheme: dialogThemeDark,
   brightness: Brightness.dark,
   primaryColor: _darkColorScheme.primary,
-  primaryColorBrightness:
-      ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
   canvasColor: _darkColorScheme.background,
   scaffoldBackgroundColor: _darkColorScheme.background,
   bottomAppBarColor: _darkColorScheme.surface,
@@ -43,10 +37,10 @@ final yaruLubuntuDark = ThemeData(
   textButtonTheme: textButtonThemeData,
   elevatedButtonTheme:
       getElevatedButtonThemeData(Brightness.dark, _primaryColor),
-  outlinedButtonTheme: _darkOutlinedButtonThemeData,
-  switchTheme: _switchStyleDark,
-  checkboxTheme: _checkStyleDark,
-  radioTheme: _radioStyleDark,
+  outlinedButtonTheme: darkOutlinedButtonThemeData,
+  switchTheme: getSwitchThemeData(_primaryColor, Brightness.dark),
+  checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.dark),
+  radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.dark),
   primaryColorDark: _primaryColor,
   appBarTheme: appBarDarkTheme,
   floatingActionButtonTheme: FloatingActionButtonThemeData(
@@ -60,67 +54,3 @@ final yaruLubuntuDark = ThemeData(
     border: OutlineInputBorder(),
   ),
 );
-
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
-    style: OutlinedButton.styleFrom(
-  visualDensity: commonButtonStyle.visualDensity,
-  primary: Colors.white,
-));
-
-// Switches
-Color _getSwitchThumbColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return YaruColors.warmGrey;
-    }
-  }
-}
-
-Color _getSwitchTrackColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark.withAlpha(120);
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(160);
-    } else {
-      return YaruColors.warmGrey.withAlpha(80);
-    }
-  }
-}
-
-final _switchStyleDark = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
-);
-
-Color _getCheckFillColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey.shade400;
-  }
-  return YaruColors.warmGrey.withOpacity(0.4);
-}
-
-Color _getCheckColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleDark = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
-);
-
-final _radioStyleDark = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark));

--- a/lib/src/themes/yaru_lubuntu_light.dart
+++ b/lib/src/themes/yaru_lubuntu_light.dart
@@ -20,8 +20,6 @@ final yaruLubuntuLight = ThemeData(
     tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
     brightness: Brightness.light,
     primaryColor: _lightColorScheme.primary,
-    primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
     canvasColor: _lightColorScheme.background,
     scaffoldBackgroundColor: _lightColorScheme.background,
     bottomAppBarColor: _lightColorScheme.surface,
@@ -39,9 +37,9 @@ final yaruLubuntuLight = ThemeData(
     elevatedButtonTheme:
         getElevatedButtonThemeData(Brightness.light, _primaryColor),
     textButtonTheme: textButtonThemeData,
-    switchTheme: _switchStyleLight,
-    checkboxTheme: _checkStyleLight,
-    radioTheme: _radioStyleLight,
+    switchTheme: getSwitchThemeData(_primaryColor, Brightness.light),
+    checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.light),
+    radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.light),
     appBarTheme: appBarLightTheme,
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: _primaryColor,
@@ -53,60 +51,3 @@ final yaruLubuntuLight = ThemeData(
     inputDecorationTheme: InputDecorationTheme(
       border: OutlineInputBorder(),
     ));
-
-Color _getSwitchThumbColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return Colors.white;
-    }
-  }
-}
-
-Color _getSwitchTrackColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(180);
-    } else {
-      return YaruColors.warmGrey.shade300;
-    }
-  }
-}
-
-final _switchStyleLight = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
-);
-
-Color _getCheckFillColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey;
-  }
-  return YaruColors.warmGrey.shade300;
-}
-
-Color _getCheckColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleLight = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
-);
-
-final _radioStyleLight = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight));

--- a/lib/src/themes/yaru_mate_dark.dart
+++ b/lib/src/themes/yaru_mate_dark.dart
@@ -18,15 +18,9 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 
 final yaruMateDark = ThemeData(
   tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onSurface),
-  dialogTheme: DialogTheme(
-      backgroundColor: YaruColors.coolGrey,
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-          side: BorderSide(color: Colors.white.withOpacity(0.2)))),
+  dialogTheme: dialogThemeDark,
   brightness: Brightness.dark,
   primaryColor: _darkColorScheme.primary,
-  primaryColorBrightness:
-      ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
   canvasColor: _darkColorScheme.background,
   scaffoldBackgroundColor: _darkColorScheme.background,
   bottomAppBarColor: _darkColorScheme.surface,
@@ -43,10 +37,10 @@ final yaruMateDark = ThemeData(
   textButtonTheme: textButtonThemeData,
   elevatedButtonTheme:
       getElevatedButtonThemeData(Brightness.dark, _primaryColor),
-  outlinedButtonTheme: _darkOutlinedButtonThemeData,
-  switchTheme: _switchStyleDark,
-  checkboxTheme: _checkStyleDark,
-  radioTheme: _radioStyleDark,
+  outlinedButtonTheme: darkOutlinedButtonThemeData,
+  switchTheme: getSwitchThemeData(_primaryColor, Brightness.dark),
+  checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.dark),
+  radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.dark),
   primaryColorDark: _primaryColor,
   appBarTheme: appBarDarkTheme,
   floatingActionButtonTheme: FloatingActionButtonThemeData(
@@ -60,67 +54,3 @@ final yaruMateDark = ThemeData(
     border: OutlineInputBorder(),
   ),
 );
-
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
-    style: OutlinedButton.styleFrom(
-  visualDensity: commonButtonStyle.visualDensity,
-  primary: Colors.white,
-));
-
-// Switches
-Color _getSwitchThumbColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return YaruColors.warmGrey;
-    }
-  }
-}
-
-Color _getSwitchTrackColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark.withAlpha(120);
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(160);
-    } else {
-      return YaruColors.warmGrey.withAlpha(80);
-    }
-  }
-}
-
-final _switchStyleDark = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
-);
-
-Color _getCheckFillColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey.shade400;
-  }
-  return YaruColors.warmGrey.withOpacity(0.4);
-}
-
-Color _getCheckColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleDark = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
-);
-
-final _radioStyleDark = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark));

--- a/lib/src/themes/yaru_mate_light.dart
+++ b/lib/src/themes/yaru_mate_light.dart
@@ -20,8 +20,6 @@ final yaruMateLight = ThemeData(
     tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
     brightness: Brightness.light,
     primaryColor: _lightColorScheme.primary,
-    primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
     canvasColor: _lightColorScheme.background,
     scaffoldBackgroundColor: _lightColorScheme.background,
     bottomAppBarColor: _lightColorScheme.surface,
@@ -39,9 +37,9 @@ final yaruMateLight = ThemeData(
     elevatedButtonTheme:
         getElevatedButtonThemeData(Brightness.light, _primaryColor),
     textButtonTheme: textButtonThemeData,
-    switchTheme: _switchStyleLight,
-    checkboxTheme: _checkStyleLight,
-    radioTheme: _radioStyleLight,
+    switchTheme: getSwitchThemeData(_primaryColor, Brightness.light),
+    checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.light),
+    radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.light),
     appBarTheme: appBarLightTheme,
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: _primaryColor,
@@ -53,60 +51,3 @@ final yaruMateLight = ThemeData(
     inputDecorationTheme: InputDecorationTheme(
       border: OutlineInputBorder(),
     ));
-
-Color _getSwitchThumbColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return Colors.white;
-    }
-  }
-}
-
-Color _getSwitchTrackColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(180);
-    } else {
-      return YaruColors.warmGrey.shade300;
-    }
-  }
-}
-
-final _switchStyleLight = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
-);
-
-Color _getCheckFillColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey;
-  }
-  return YaruColors.warmGrey.shade300;
-}
-
-Color _getCheckColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleLight = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
-);
-
-final _radioStyleLight = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight));

--- a/lib/src/themes/yaru_ubuntu_budgie_dark.dart
+++ b/lib/src/themes/yaru_ubuntu_budgie_dark.dart
@@ -18,15 +18,9 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 
 final yaruUbuntuBudgieDark = ThemeData(
   tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onSurface),
-  dialogTheme: DialogTheme(
-      backgroundColor: YaruColors.coolGrey,
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-          side: BorderSide(color: Colors.white.withOpacity(0.2)))),
+  dialogTheme: dialogThemeDark,
   brightness: Brightness.dark,
   primaryColor: _darkColorScheme.primary,
-  primaryColorBrightness:
-      ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
   canvasColor: _darkColorScheme.background,
   scaffoldBackgroundColor: _darkColorScheme.background,
   bottomAppBarColor: _darkColorScheme.surface,
@@ -43,10 +37,10 @@ final yaruUbuntuBudgieDark = ThemeData(
   textButtonTheme: textButtonThemeData,
   elevatedButtonTheme:
       getElevatedButtonThemeData(Brightness.dark, _primaryColor),
-  outlinedButtonTheme: _darkOutlinedButtonThemeData,
-  switchTheme: _switchStyleDark,
-  checkboxTheme: _checkStyleDark,
-  radioTheme: _radioStyleDark,
+  outlinedButtonTheme: darkOutlinedButtonThemeData,
+  switchTheme: getSwitchThemeData(_primaryColor, Brightness.dark),
+  checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.dark),
+  radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.dark),
   primaryColorDark: _primaryColor,
   appBarTheme: appBarDarkTheme,
   floatingActionButtonTheme: FloatingActionButtonThemeData(
@@ -60,67 +54,3 @@ final yaruUbuntuBudgieDark = ThemeData(
     border: OutlineInputBorder(),
   ),
 );
-
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
-    style: OutlinedButton.styleFrom(
-  visualDensity: commonButtonStyle.visualDensity,
-  primary: Colors.white,
-));
-
-// Switches
-Color _getSwitchThumbColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return YaruColors.warmGrey;
-    }
-  }
-}
-
-Color _getSwitchTrackColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark.withAlpha(120);
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(160);
-    } else {
-      return YaruColors.warmGrey.withAlpha(80);
-    }
-  }
-}
-
-final _switchStyleDark = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
-);
-
-Color _getCheckFillColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey.shade400;
-  }
-  return YaruColors.warmGrey.withOpacity(0.4);
-}
-
-Color _getCheckColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleDark = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
-);
-
-final _radioStyleDark = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark));

--- a/lib/src/themes/yaru_ubuntu_budgie_light.dart
+++ b/lib/src/themes/yaru_ubuntu_budgie_light.dart
@@ -20,8 +20,6 @@ final yaruUbuntuBudgieLight = ThemeData(
     tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
     brightness: Brightness.light,
     primaryColor: _lightColorScheme.primary,
-    primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
     canvasColor: _lightColorScheme.background,
     scaffoldBackgroundColor: _lightColorScheme.background,
     bottomAppBarColor: _lightColorScheme.surface,
@@ -39,9 +37,9 @@ final yaruUbuntuBudgieLight = ThemeData(
     elevatedButtonTheme:
         getElevatedButtonThemeData(Brightness.light, _primaryColor),
     textButtonTheme: textButtonThemeData,
-    switchTheme: _switchStyleLight,
-    checkboxTheme: _checkStyleLight,
-    radioTheme: _radioStyleLight,
+    switchTheme: getSwitchThemeData(_primaryColor, Brightness.light),
+    checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.light),
+    radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.light),
     appBarTheme: appBarLightTheme,
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: _primaryColor,
@@ -53,60 +51,3 @@ final yaruUbuntuBudgieLight = ThemeData(
     inputDecorationTheme: InputDecorationTheme(
       border: OutlineInputBorder(),
     ));
-
-Color _getSwitchThumbColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return Colors.white;
-    }
-  }
-}
-
-Color _getSwitchTrackColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(180);
-    } else {
-      return YaruColors.warmGrey.shade300;
-    }
-  }
-}
-
-final _switchStyleLight = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
-);
-
-Color _getCheckFillColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey;
-  }
-  return YaruColors.warmGrey.shade300;
-}
-
-Color _getCheckColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleLight = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
-);
-
-final _radioStyleLight = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight));

--- a/lib/src/themes/yaru_ubuntu_studio_dark.dart
+++ b/lib/src/themes/yaru_ubuntu_studio_dark.dart
@@ -18,15 +18,9 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 
 final yaruUbuntuStudioDark = ThemeData(
   tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onSurface),
-  dialogTheme: DialogTheme(
-      backgroundColor: YaruColors.coolGrey,
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-          side: BorderSide(color: Colors.white.withOpacity(0.2)))),
+  dialogTheme: dialogThemeDark,
   brightness: Brightness.dark,
   primaryColor: _darkColorScheme.primary,
-  primaryColorBrightness:
-      ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
   canvasColor: _darkColorScheme.background,
   scaffoldBackgroundColor: _darkColorScheme.background,
   bottomAppBarColor: _darkColorScheme.surface,
@@ -43,10 +37,10 @@ final yaruUbuntuStudioDark = ThemeData(
   textButtonTheme: textButtonThemeData,
   elevatedButtonTheme:
       getElevatedButtonThemeData(Brightness.dark, _primaryColor),
-  outlinedButtonTheme: _darkOutlinedButtonThemeData,
-  switchTheme: _switchStyleDark,
-  checkboxTheme: _checkStyleDark,
-  radioTheme: _radioStyleDark,
+  outlinedButtonTheme: darkOutlinedButtonThemeData,
+  switchTheme: getSwitchThemeData(_primaryColor, Brightness.dark),
+  checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.dark),
+  radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.dark),
   primaryColorDark: _primaryColor,
   appBarTheme: appBarDarkTheme,
   floatingActionButtonTheme: FloatingActionButtonThemeData(
@@ -60,67 +54,3 @@ final yaruUbuntuStudioDark = ThemeData(
     border: OutlineInputBorder(),
   ),
 );
-
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
-    style: OutlinedButton.styleFrom(
-  visualDensity: commonButtonStyle.visualDensity,
-  primary: Colors.white,
-));
-
-// Switches
-Color _getSwitchThumbColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return YaruColors.warmGrey;
-    }
-  }
-}
-
-Color _getSwitchTrackColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark.withAlpha(120);
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(160);
-    } else {
-      return YaruColors.warmGrey.withAlpha(80);
-    }
-  }
-}
-
-final _switchStyleDark = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
-);
-
-Color _getCheckFillColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey.shade400;
-  }
-  return YaruColors.warmGrey.withOpacity(0.4);
-}
-
-Color _getCheckColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleDark = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
-);
-
-final _radioStyleDark = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark));

--- a/lib/src/themes/yaru_ubuntu_studio_light.dart
+++ b/lib/src/themes/yaru_ubuntu_studio_light.dart
@@ -20,8 +20,6 @@ final yaruUbuntuStudioLight = ThemeData(
     tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
     brightness: Brightness.light,
     primaryColor: _lightColorScheme.primary,
-    primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
     canvasColor: _lightColorScheme.background,
     scaffoldBackgroundColor: _lightColorScheme.background,
     bottomAppBarColor: _lightColorScheme.surface,
@@ -39,9 +37,9 @@ final yaruUbuntuStudioLight = ThemeData(
     elevatedButtonTheme:
         getElevatedButtonThemeData(Brightness.light, _primaryColor),
     textButtonTheme: textButtonThemeData,
-    switchTheme: _switchStyleLight,
-    checkboxTheme: _checkStyleLight,
-    radioTheme: _radioStyleLight,
+    switchTheme: getSwitchThemeData(_primaryColor, Brightness.light),
+    checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.light),
+    radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.light),
     appBarTheme: appBarLightTheme,
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: _primaryColor,
@@ -53,60 +51,3 @@ final yaruUbuntuStudioLight = ThemeData(
     inputDecorationTheme: InputDecorationTheme(
       border: OutlineInputBorder(),
     ));
-
-Color _getSwitchThumbColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return Colors.white;
-    }
-  }
-}
-
-Color _getSwitchTrackColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(180);
-    } else {
-      return YaruColors.warmGrey.shade300;
-    }
-  }
-}
-
-final _switchStyleLight = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
-);
-
-Color _getCheckFillColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey;
-  }
-  return YaruColors.warmGrey.shade300;
-}
-
-Color _getCheckColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleLight = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
-);
-
-final _radioStyleLight = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight));

--- a/lib/src/themes/yaru_xubuntu_dark.dart
+++ b/lib/src/themes/yaru_xubuntu_dark.dart
@@ -18,15 +18,9 @@ final _darkColorScheme = ColorScheme.fromSwatch(
 
 final yaruXubuntuDark = ThemeData(
   tabBarTheme: TabBarTheme(labelColor: _darkColorScheme.onSurface),
-  dialogTheme: DialogTheme(
-      backgroundColor: YaruColors.coolGrey,
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-          side: BorderSide(color: Colors.white.withOpacity(0.2)))),
+  dialogTheme: dialogThemeDark,
   brightness: Brightness.dark,
   primaryColor: _darkColorScheme.primary,
-  primaryColorBrightness:
-      ThemeData.estimateBrightnessForColor(_darkColorScheme.primary),
   canvasColor: _darkColorScheme.background,
   scaffoldBackgroundColor: _darkColorScheme.background,
   bottomAppBarColor: _darkColorScheme.surface,
@@ -43,10 +37,10 @@ final yaruXubuntuDark = ThemeData(
   textButtonTheme: textButtonThemeData,
   elevatedButtonTheme:
       getElevatedButtonThemeData(Brightness.dark, _primaryColor),
-  outlinedButtonTheme: _darkOutlinedButtonThemeData,
-  switchTheme: _switchStyleDark,
-  checkboxTheme: _checkStyleDark,
-  radioTheme: _radioStyleDark,
+  outlinedButtonTheme: darkOutlinedButtonThemeData,
+  switchTheme: getSwitchThemeData(_primaryColor, Brightness.dark),
+  checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.dark),
+  radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.dark),
   primaryColorDark: _primaryColor,
   appBarTheme: appBarDarkTheme,
   floatingActionButtonTheme: FloatingActionButtonThemeData(
@@ -60,67 +54,3 @@ final yaruXubuntuDark = ThemeData(
     border: OutlineInputBorder(),
   ),
 );
-
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
-    style: OutlinedButton.styleFrom(
-  visualDensity: commonButtonStyle.visualDensity,
-  primary: Colors.white,
-));
-
-// Switches
-Color _getSwitchThumbColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return YaruColors.warmGrey;
-    }
-  }
-}
-
-Color _getSwitchTrackColorDark(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.disabledGreyDark.withAlpha(120);
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(160);
-    } else {
-      return YaruColors.warmGrey.withAlpha(80);
-    }
-  }
-}
-
-final _switchStyleDark = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorDark),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorDark),
-);
-
-Color _getCheckFillColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey.shade400;
-  }
-  return YaruColors.warmGrey.withOpacity(0.4);
-}
-
-Color _getCheckColorDark(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleDark = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorDark),
-);
-
-final _radioStyleDark = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorDark));

--- a/lib/src/themes/yaru_xubuntu_light.dart
+++ b/lib/src/themes/yaru_xubuntu_light.dart
@@ -20,8 +20,6 @@ final yaruXubuntuLight = ThemeData(
     tabBarTheme: TabBarTheme(labelColor: _lightColorScheme.onSurface),
     brightness: Brightness.light,
     primaryColor: _lightColorScheme.primary,
-    primaryColorBrightness:
-        ThemeData.estimateBrightnessForColor(_lightColorScheme.primary),
     canvasColor: _lightColorScheme.background,
     scaffoldBackgroundColor: _lightColorScheme.background,
     bottomAppBarColor: _lightColorScheme.surface,
@@ -39,9 +37,9 @@ final yaruXubuntuLight = ThemeData(
     elevatedButtonTheme:
         getElevatedButtonThemeData(Brightness.light, _primaryColor),
     textButtonTheme: textButtonThemeData,
-    switchTheme: _switchStyleLight,
-    checkboxTheme: _checkStyleLight,
-    radioTheme: _radioStyleLight,
+    switchTheme: getSwitchThemeData(_primaryColor, Brightness.light),
+    checkboxTheme: getCheckBoxThemeDataDark(_primaryColor, Brightness.light),
+    radioTheme: getRadioThemeDataDark(_primaryColor, Brightness.light),
     appBarTheme: appBarLightTheme,
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: _primaryColor,
@@ -53,60 +51,3 @@ final yaruXubuntuLight = ThemeData(
     inputDecorationTheme: InputDecorationTheme(
       border: OutlineInputBorder(),
     ));
-
-Color _getSwitchThumbColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    } else {
-      return Colors.white;
-    }
-  }
-}
-
-Color _getSwitchTrackColorLight(Set<MaterialState> states) {
-  if (states.contains(MaterialState.disabled)) {
-    return YaruColors.warmGrey.shade200;
-  } else {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor.withAlpha(180);
-    } else {
-      return YaruColors.warmGrey.shade300;
-    }
-  }
-}
-
-final _switchStyleLight = SwitchThemeData(
-  thumbColor: MaterialStateProperty.resolveWith(_getSwitchThumbColorLight),
-  trackColor: MaterialStateProperty.resolveWith(_getSwitchTrackColorLight),
-);
-
-Color _getCheckFillColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    if (states.contains(MaterialState.selected)) {
-      return _primaryColor;
-    }
-    return YaruColors.warmGrey;
-  }
-  return YaruColors.warmGrey.shade300;
-}
-
-Color _getCheckColorLight(Set<MaterialState> states) {
-  if (!states.contains(MaterialState.disabled)) {
-    return Colors.white;
-  }
-  return YaruColors.warmGrey;
-}
-
-final _checkStyleLight = CheckboxThemeData(
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(2),
-  ),
-  fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight),
-  checkColor: MaterialStateProperty.resolveWith(_getCheckColorLight),
-);
-
-final _radioStyleLight = RadioThemeData(
-    fillColor: MaterialStateProperty.resolveWith(_getCheckFillColorLight));


### PR DESCRIPTION
- get most of the theming from functions from common_themes
- use constants for fixed numbers
- remove deprecated primaryColorBrightness property
- no visual changes