### PR TITLE
Detach appbar from yaru colors

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,6 +19,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Yaru Example',
       theme: theme,
+      debugShowCheckedModeBanner: false,
       home: HomePage(
           themeChanged: (themeName) => setState(() {
                 if (themeName == 'Yaru-light') {

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -6,29 +6,33 @@ import 'package:yaru/src/themes/constants.dart';
 
 // AppBar
 
-final appBarLightTheme = AppBarTheme(
-  elevation: appBarElevation,
-  systemOverlayStyle: SystemUiOverlayStyle.light,
-  backgroundColor: YaruColors.porcelain,
-  foregroundColor: YaruColors.coolGrey,
-  titleTextStyle: textTheme.headline6!.copyWith(
-    color: YaruColors.coolGrey,
-    fontWeight: FontWeight.normal,
-  ),
-  iconTheme: IconThemeData(color: YaruColors.coolGrey),
-  actionsIconTheme: IconThemeData(color: YaruColors.coolGrey),
-);
+AppBarTheme createLightAppBar(ColorScheme colorScheme) {
+  return AppBarTheme(
+    elevation: appBarElevation,
+    systemOverlayStyle: SystemUiOverlayStyle.light,
+    backgroundColor: colorScheme.background,
+    foregroundColor: colorScheme.onSurface.withOpacity(0.75),
+    titleTextStyle: textTheme.headline6!.copyWith(
+      color: colorScheme.onSurface.withOpacity(0.75),
+      fontWeight: FontWeight.normal,
+    ),
+    iconTheme: IconThemeData(color: colorScheme.onBackground),
+    actionsIconTheme: IconThemeData(color: colorScheme.onBackground),
+  );
+}
 
-final appBarDarkTheme = AppBarTheme(
-  elevation: appBarElevation,
-  systemOverlayStyle: SystemUiOverlayStyle.dark,
-  backgroundColor: YaruColors.jet,
-  foregroundColor: YaruColors.porcelain,
-  titleTextStyle: textTheme.headline6!.copyWith(
-    color: YaruColors.porcelain,
-    fontWeight: FontWeight.normal,
-  ),
-);
+AppBarTheme createDarkAppBarTheme(ColorScheme colorScheme) {
+  return AppBarTheme(
+    elevation: appBarElevation,
+    systemOverlayStyle: SystemUiOverlayStyle.dark,
+    backgroundColor: colorScheme.surface,
+    foregroundColor: colorScheme.onSurface,
+    titleTextStyle: textTheme.headline6!.copyWith(
+      color: colorScheme.onSurface,
+      fontWeight: FontWeight.normal,
+    ),
+  );
+}
 
 // Buttons
 
@@ -191,7 +195,7 @@ ThemeData createYaruLightTheme(
       switchTheme: getSwitchThemeData(primaryColor, Brightness.light),
       checkboxTheme: getCheckBoxThemeData(primaryColor, Brightness.light),
       radioTheme: getRadioThemeData(primaryColor, Brightness.light),
-      appBarTheme: appBarLightTheme,
+      appBarTheme: createLightAppBar(colorScheme),
       floatingActionButtonTheme: FloatingActionButtonThemeData(
         backgroundColor: elevatedButtonColor ?? primaryColor,
       ),
@@ -235,7 +239,7 @@ ThemeData createYaruDarkTheme(
     checkboxTheme: getCheckBoxThemeData(primaryColor, Brightness.dark),
     radioTheme: getRadioThemeData(primaryColor, Brightness.dark),
     primaryColorDark: primaryColor,
-    appBarTheme: appBarDarkTheme,
+    appBarTheme: createDarkAppBarTheme(colorScheme),
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: elevatedButtonColor ?? primaryColor,
     ),


### PR DESCRIPTION
detach AppBarTheme from YaruColors

- use helper functions to create AppBarThemes based on a colorScheme
- remove debug label
- no visual changes

![grafik](https://user-images.githubusercontent.com/15329494/151659871-579d5c4c-19d0-45cc-b928-f30ccf5e4a5c.png)
![grafik](https://user-images.githubusercontent.com/15329494/151659880-f997b630-376c-4107-b556-8b55eab0b486.png)
