### PR TITLE
Increase border radii to match gnome themes

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -63,6 +63,9 @@ final _outlinedButtonThemeData = OutlinedButtonThemeData(
 
 final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(
+  shape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.circular(kButtonRadius),
+  ),
   visualDensity: _commonButtonStyle.visualDensity,
   primary: Colors.white,
 ));

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -1,5 +1,5 @@
-const kButtonRadius = 4.0;
+const kButtonRadius = 6.0;
 const kCheckRadius = 3.0;
-const kWindowRadius = 6.0;
+const kWindowRadius = 8.0;
 const kAppBarElevation = 1.0;
 const kAppBarHeight = 48.0;


### PR DESCRIPTION
| Before | After |
|-|-|
|![Bildschirmfoto von 2022-02-19 00-08-12](https://user-images.githubusercontent.com/15329494/154772974-e63a1f0c-2d92-4fe4-9810-a8a5ef586c6f.png) | ![Bildschirmfoto von 2022-02-19 00-07-31](https://user-images.githubusercontent.com/15329494/154772982-05d19ff2-c377-4cfd-8504-dd5ab7caec5f.png)|
|![Bildschirmfoto von 2022-02-19 00-08-04](https://user-images.githubusercontent.com/15329494/154772979-b8020cb5-c255-4dd5-aa2d-16f2dcccceb9.png) |![Bildschirmfoto von 2022-02-19 00-07-50](https://user-images.githubusercontent.com/15329494/154772980-22ae9e6c-ffc0-4aa0-801d-b9c74fd38c89.png) |







Closes #133 