### PR TITLE
Let Flutter help with high-contrast colors

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -112,8 +112,7 @@ final _dialogThemeLight = DialogTheme(
 
 // Switches
 
-SwitchThemeData _getSwitchThemeData(
-    MaterialColor primaryColor, Brightness brightness) {
+SwitchThemeData _getSwitchThemeData(Color primaryColor, Brightness brightness) {
   return SwitchThemeData(
       thumbColor: MaterialStateProperty.resolveWith(
           (states) => _getSwitchThumbColor(states, primaryColor, brightness)),
@@ -121,8 +120,8 @@ SwitchThemeData _getSwitchThemeData(
           (states) => _getSwitchTrackColor(states, primaryColor, brightness)));
 }
 
-Color _getSwitchThumbColor(Set<MaterialState> states,
-    MaterialColor selectedColor, Brightness brightness) {
+Color _getSwitchThumbColor(
+    Set<MaterialState> states, Color selectedColor, Brightness brightness) {
   if (states.contains(MaterialState.disabled)) {
     return brightness == Brightness.dark
         ? YaruColors.disabledGreyDark
@@ -136,8 +135,8 @@ Color _getSwitchThumbColor(Set<MaterialState> states,
   }
 }
 
-Color _getSwitchTrackColor(Set<MaterialState> states,
-    MaterialColor selectedColor, Brightness brightness) {
+Color _getSwitchTrackColor(
+    Set<MaterialState> states, Color selectedColor, Brightness brightness) {
   if (states.contains(MaterialState.disabled)) {
     return brightness == Brightness.dark
         ? YaruColors.disabledGreyDark.withAlpha(120)
@@ -157,8 +156,8 @@ Color _getSwitchTrackColor(Set<MaterialState> states,
 
 // Checks & Radios
 
-Color _getCheckFillColor(Set<MaterialState> states, MaterialColor selectedColor,
-    Brightness brightness) {
+Color _getCheckFillColor(
+    Set<MaterialState> states, Color selectedColor, Brightness brightness) {
   if (!states.contains(MaterialState.disabled)) {
     if (states.contains(MaterialState.selected)) {
       return selectedColor;
@@ -182,7 +181,7 @@ Color _getCheckColor(Set<MaterialState> states, Color color) {
 }
 
 CheckboxThemeData _getCheckBoxThemeData(
-    MaterialColor primaryColor, Brightness brightness) {
+    Color primaryColor, Brightness brightness) {
   return CheckboxThemeData(
     shape: RoundedRectangleBorder(
       borderRadius: BorderRadius.circular(kCheckRadius),
@@ -190,12 +189,11 @@ CheckboxThemeData _getCheckBoxThemeData(
     fillColor: MaterialStateProperty.resolveWith(
         (states) => _getCheckFillColor(states, primaryColor, brightness)),
     checkColor: MaterialStateProperty.resolveWith(
-        (states) => _getCheckColor(states, primaryColor.shade500)),
+        (states) => _getCheckColor(states, primaryColor)),
   );
 }
 
-RadioThemeData _getRadioThemeData(
-    MaterialColor primaryColor, Brightness brightness) {
+RadioThemeData _getRadioThemeData(Color primaryColor, Brightness brightness) {
   return RadioThemeData(
       fillColor: MaterialStateProperty.resolveWith(
           (states) => _getCheckFillColor(states, primaryColor, brightness)));
@@ -204,7 +202,7 @@ RadioThemeData _getRadioThemeData(
 /// Helper function to create a new Yaru light theme
 ThemeData createYaruLightTheme(
     {required ColorScheme colorScheme,
-    required MaterialColor primaryColor,
+    required Color primaryColor,
     Color? elevatedButtonColor}) {
   return ThemeData(
     tabBarTheme: TabBarTheme(labelColor: colorScheme.onSurface),
@@ -247,7 +245,7 @@ ThemeData createYaruLightTheme(
 /// Helper function to create a new Yaru dark theme
 ThemeData createYaruDarkTheme(
     {required ColorScheme colorScheme,
-    required MaterialColor primaryColor,
+    required Color primaryColor,
     Color? elevatedButtonColor}) {
   return ThemeData(
     tabBarTheme: TabBarTheme(labelColor: Colors.white.withOpacity(0.8)),

--- a/lib/src/themes/high_contrast.dart
+++ b/lib/src/themes/high_contrast.dart
@@ -3,30 +3,22 @@ import 'package:yaru/src/colors/yaru_colors.dart';
 
 import 'package:yaru/src/themes/common_themes.dart';
 
-final b = YaruColors.createMaterialColor(Colors.black);
 final yaruHighContrastLight = createYaruLightTheme(
-  colorScheme: ColorScheme.fromSwatch(
-    primarySwatch: b,
-    primaryColorDark: YaruColors.coolGrey,
-    accentColor: Colors.black,
-    cardColor: Colors.white,
-    backgroundColor: Colors.white,
-    errorColor: YaruColors.red,
-    brightness: Brightness.light,
+  colorScheme: const ColorScheme.highContrastLight(
+    primary: Colors.black,
+    secondary: Colors.black,
+    onSecondary: Colors.white,
+    error: YaruColors.red,
   ),
-  primaryColor: b,
+  primaryColor: Colors.black,
 );
 
-final w = YaruColors.createMaterialColor(Colors.white);
 final yaruHighContrastDark = createYaruDarkTheme(
-  colorScheme: ColorScheme.fromSwatch(
-    primarySwatch: w,
-    primaryColorDark: Colors.white,
-    accentColor: Colors.white,
-    cardColor: Colors.black,
-    backgroundColor: Colors.black,
-    errorColor: YaruColors.red,
-    brightness: Brightness.dark,
+  colorScheme: const ColorScheme.highContrastDark(
+    primary: Colors.white,
+    secondary: Colors.white,
+    onSecondary: Colors.black,
+    error: YaruColors.red,
   ),
-  primaryColor: w,
+  primaryColor: Colors.white,
 );


### PR DESCRIPTION
There's very little visual difference. This gets rid of the `YaruColors.createMaterialColor()` dependency in high-contrast themes.

| Before | After |
|---|---|
| ![Screenshot from 2022-04-20 15-11-15](https://user-images.githubusercontent.com/140617/164238419-9495fa00-20c5-40ce-9903-321875684dca.png) | ![Screenshot from 2022-04-20 15-10-40](https://user-images.githubusercontent.com/140617/164238462-384014cb-40c3-4eec-af70-4255b8413e55.png) |
| ![Screenshot from 2022-04-20 15-11-19](https://user-images.githubusercontent.com/140617/164238430-d4639f26-90fb-4da8-a518-f57107b2350f.png) | ![Screenshot from 2022-04-20 15-10-44](https://user-images.githubusercontent.com/140617/164238505-d1288dd7-9858-47d8-b986-667c1a12e420.png) |