### PR TITLE
Pair YaruAccent with its accent color

### DIFF
--- a/example/lib/view/home_page.dart
+++ b/example/lib/view/home_page.dart
@@ -69,7 +69,7 @@ class _HomePageState extends State<HomePage> {
               onPressed: () => AppTheme.apply(context, highContrast: true)),
           for (final accent in YaruAccent.values)
             ColorDisk(
-              color: getYaruLightTheme(accent).primaryColor,
+              color: accent.color,
               selected: accent == theme.accent && theme.highContrast != true,
               onPressed: () =>
                   AppTheme.apply(context, accent: accent, highContrast: false),

--- a/lib/src/themes/yaru_accents.dart
+++ b/lib/src/themes/yaru_accents.dart
@@ -4,17 +4,36 @@ import 'package:yaru/src/themes/common_themes.dart';
 import 'package:yaru/src/themes/yaru_dark.dart';
 import 'package:yaru/src/themes/yaru_light.dart';
 
-enum YaruAccent {
-  orange,
-  bark,
-  sage,
-  olive,
-  viridian,
-  prussianGreen,
-  blue,
-  purple,
-  magenta,
-  red,
+class YaruAccent {
+  const YaruAccent._(this.name, this.color);
+
+  final String name;
+  final MaterialColor color;
+
+  static const orange = YaruAccent._('orange', YaruColors.ubuntuOrange);
+  static const bark = YaruAccent._('bark', YaruColors.bark);
+  static const sage = YaruAccent._('sage', YaruColors.sage);
+  static const olive = YaruAccent._('olive', YaruColors.olive);
+  static const viridian = YaruAccent._('viridian', YaruColors.viridian);
+  static const prussianGreen =
+      YaruAccent._('prussianGreen', YaruColors.prussianGreen);
+  static const blue = YaruAccent._('blue', YaruColors.blue);
+  static const purple = YaruAccent._('purple', YaruColors.purple);
+  static const magenta = YaruAccent._('magenta', YaruColors.magenta);
+  static const red = YaruAccent._('red', YaruColors.lightRed);
+
+  static const List<YaruAccent> values = [
+    orange,
+    bark,
+    sage,
+    olive,
+    viridian,
+    prussianGreen,
+    blue,
+    purple,
+    magenta,
+    red,
+  ];
 }
 
 ThemeData getYaruLightTheme(YaruAccent accent) {

--- a/lib/src/widgets/inherited_theme.dart
+++ b/lib/src/widgets/inherited_theme.dart
@@ -44,29 +44,6 @@ YaruFlavor? _detectYaruFlavor(Platform platform) {
   return null;
 }
 
-const _yaruAccents = <String, YaruAccent>{
-  'Yaru': YaruAccent.orange,
-  'Yaru-dark': YaruAccent.orange,
-  'Yaru-bark': YaruAccent.bark,
-  'Yaru-bark-dark': YaruAccent.bark,
-  'Yaru-sage': YaruAccent.sage,
-  'Yaru-sage-dark': YaruAccent.sage,
-  'Yaru-olive': YaruAccent.olive,
-  'Yaru-olive-dark': YaruAccent.olive,
-  'Yaru-viridian': YaruAccent.viridian,
-  'Yaru-viridian-dark': YaruAccent.viridian,
-  'Yaru-prussiangreen': YaruAccent.prussianGreen,
-  'Yaru-prussiangreen-dark': YaruAccent.prussianGreen,
-  'Yaru-blue': YaruAccent.blue,
-  'Yaru-blue-dark': YaruAccent.blue,
-  'Yaru-purple': YaruAccent.purple,
-  'Yaru-purple-dark': YaruAccent.purple,
-  'Yaru-magenta': YaruAccent.magenta,
-  'Yaru-magenta-dark': YaruAccent.magenta,
-  'Yaru-red': YaruAccent.red,
-  'Yaru-red-dark': YaruAccent.red,
-};
-
 /// Applies Yaru theme to descendant widgets.
 ///
 /// Descendant widgets obtain the current theme's [YaruThemeData] object using
@@ -146,10 +123,29 @@ class _YaruThemeState extends State<YaruTheme> {
     }
   }
 
+  // "Yaru-prussiangreen-dark" => YaruAccent.prussianGreen
+  YaruAccent? resolveAccent(String name) {
+    if (name.endsWith('-dark')) {
+      name = name.substring(0, name.length - 5);
+    }
+    if (name.startsWith('Yaru-')) {
+      name = name.substring(5);
+    }
+    if (name == 'Yaru') {
+      return YaruAccent.orange;
+    }
+    for (var value in YaruAccent.values) {
+      if (value.name.toLowerCase() == name.toLowerCase()) {
+        return value;
+      }
+    }
+    return null;
+  }
+
   Future<void> updateAccent() async {
     assert(!kIsWeb && widget._platform.isLinux);
     final name = await _settings?.get('gtk-theme') as DBusString;
-    setState(() => _accent = _yaruAccents[name.value]);
+    setState(() => _accent = resolveAccent(name.value));
   }
 
   ThemeMode resolveMode() {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -34,6 +34,28 @@ void main() {
       final settings = MockGSettings();
       when(settings.keysChanged).thenAnswer((_) => Stream.empty());
       when(settings.get('gtk-theme'))
+          .thenAnswer((_) async => DBusString('Yaru'));
+
+      await tester.pumpTheme(settings: settings);
+      final context = tester.element(find.byType(Container));
+      expect(YaruTheme.of(context).accent, YaruAccent.orange);
+    });
+
+    testWidgets('dark', (tester) async {
+      final settings = MockGSettings();
+      when(settings.keysChanged).thenAnswer((_) => Stream.empty());
+      when(settings.get('gtk-theme'))
+          .thenAnswer((_) async => DBusString('Yaru-dark'));
+
+      await tester.pumpTheme(settings: settings);
+      final context = tester.element(find.byType(Container));
+      expect(YaruTheme.of(context).accent, YaruAccent.orange);
+    });
+
+    testWidgets('color', (tester) async {
+      final settings = MockGSettings();
+      when(settings.keysChanged).thenAnswer((_) => Stream.empty());
+      when(settings.get('gtk-theme'))
           .thenAnswer((_) async => DBusString('Yaru-blue'));
 
       await tester.pumpTheme(settings: settings);


### PR DESCRIPTION
Implement `YaruAccent` as a custom enum similarly to e.g. `TextInputType` in Flutter. This makes it possible to access the color directly when working with `YaruAccent` instances.