### PR TITLE
Pair YaruFlavor with its flavor color

### DIFF
--- a/lib/src/themes/yaru_flavors.dart
+++ b/lib/src/themes/yaru_flavors.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:yaru/src/colors/yaru_colors.dart';
+import 'package:yaru/src/colors/flavor_colors.dart';
+
+/// Describes a Yaru flavor and its primary color.
+class YaruFlavor {
+  const YaruFlavor._(this.name, this.color);
+
+  /// The name of the flavor.
+  final String name;
+
+  /// The primary color of the flavor.
+  final MaterialColor color;
+
+  /// Ubuntu Budgie
+  static const budgie = YaruFlavor._('budgie', FlavorColors.ubuntuBudgieBlue);
+
+  /// Kubuntu
+  static const kubuntu = YaruFlavor._('kubuntu', FlavorColors.kubuntuBlue);
+
+  /// Lubuntu
+  static const lubuntu = YaruFlavor._('lubuntu', FlavorColors.lubuntuBlue);
+
+  /// Ubuntu MATE
+  static const mate = YaruFlavor._('mate', FlavorColors.ubuntuMateGreen);
+
+  /// Ubuntu Studio
+  static const studio = YaruFlavor._('studio', FlavorColors.ubuntuStudioBlue);
+
+  /// Ubuntu
+  ///
+  /// **Note**: Ubuntu supports multiple accent colors. See [YaruAccent].
+  static const ubuntu = YaruFlavor._('ubuntu', YaruColors.ubuntuOrange);
+
+  /// Xubuntu
+  static const xubuntu = YaruFlavor._('xubuntu', FlavorColors.xubuntuBlue);
+
+  /// Available Yaru flavors.
+  static const List<YaruFlavor> values = [
+    budgie,
+    kubuntu,
+    lubuntu,
+    mate,
+    studio,
+    ubuntu,
+    xubuntu,
+  ];
+}

--- a/lib/src/widgets/inherited_theme.dart
+++ b/lib/src/widgets/inherited_theme.dart
@@ -8,27 +8,6 @@ import 'package:platform/platform.dart';
 
 import 'package:yaru/yaru.dart';
 
-/// Available Yaru flavors.
-enum YaruFlavor {
-  /// Ubuntu Budgie
-  budgie,
-
-  /// Kubuntu
-  kubuntu,
-
-  /// Lubuntu
-  lubuntu,
-
-  /// Ubuntu MATE
-  mate,
-
-  /// Ubuntu
-  ubuntu,
-
-  /// Xubuntu
-  xubuntu,
-}
-
 YaruFlavor? _detectYaruFlavor(Platform platform) {
   final desktop = !kIsWeb
       ? platform.environment['XDG_CURRENT_DESKTOP']?.toUpperCase()

--- a/lib/yaru.dart
+++ b/lib/yaru.dart
@@ -6,6 +6,7 @@ export 'package:yaru/src/themes/common_themes.dart';
 export 'package:yaru/src/themes/high_contrast.dart';
 export 'package:yaru/src/themes/yaru_accents.dart';
 export 'package:yaru/src/themes/yaru_dark.dart';
+export 'package:yaru/src/themes/yaru_flavors.dart';
 export 'package:yaru/src/themes/yaru_kubuntu_dark.dart';
 export 'package:yaru/src/themes/yaru_kubuntu_light.dart';
 export 'package:yaru/src/themes/yaru_light.dart';


### PR DESCRIPTION
Implement YaruFlavor as a custom enum similarly to e.g. TextInputTypein Flutter.