### PR TITLE
Add missing Ubuntu Font license

### DIFF
--- a/lib/src/text/fonts/CONTRIBUTING.txt
+++ b/lib/src/text/fonts/CONTRIBUTING.txt
@@ -1,0 +1,21 @@
+The Ubuntu Font Family is very long-term endeavour, and the first time
+that a professionally-designed font has been funded specifically with
+the intent of being an on-going community expanded project:
+
+  http://font.ubuntu.com/
+
+Development of the Ubuntu Font Family is undertaken on Launchpad:
+
+  http://launchpad.net/ubuntu-font-family/
+
+and this is where milestones, bug management and releases are handled.
+
+Contributions are welcomed.  Your work will be used on millions of
+computers every single day!  Following the initial bootstrapping of
+Latin, Cyrillic, Greek, Arabic and Hebrew expansion will be undertaken
+by font designers from the font design and Ubuntu communities.
+
+To ensure that the Ubuntu Font Family can be re-licensed to future
+widely-used libre font licences, copyright assignment is being required:
+
+  https://launchpad.net/~uff-contributors

--- a/lib/src/text/fonts/FONTLOG.txt
+++ b/lib/src/text/fonts/FONTLOG.txt
@@ -1,0 +1,292 @@
+This is the FONTLOG file for the Ubuntu Font Family and attempts to follow
+the recommendations at:  http://scripts.sil.org/OFL-FAQ_web#43cecb44
+
+
+Overview
+
+The new Ubuntu Font Family was started to enable the personality of
+Ubuntu to be seen and felt in every menu, button and dialog.
+The typeface is sans-serif, uses OpenType features and is manually
+hinted for clarity on desktop and mobile computing screens.
+
+The scope of the Ubuntu Font Family includes all the languages used by
+the various Ubuntu users around the world in tune with Ubuntu's
+philosophy which states that every user should be able to use their
+software in the language of their choice. So the Ubuntu Font Family
+project will be extended to cover many more written languages.
+
+
+History
+
+The Ubuntu Font Family has been creating during 2010 and 2011.  As of
+September 2011 coverage is provided for Latin, Cyrillic and Greek across
+Regular, Italic, Bold and Bold-Italic.  Further work was uptaken during
+2015.
+
+
+ChangeLog
+
+2015-08-21 (Paul Sladen) Ubuntu Font Family version 0.83
+
+  Note: This release was created by binary patching from the v0.80
+  release using the scripts in 'sources/patch-0.80-0.83/' to rebuild
+  the necessary tables. The release selectively updates only those
+  proportional .ttf font files exhibiting the bug below bug number;
+  the Ubuntu Mono monospace font files remain unchanged, being the
+  original version 0.80 ones.
+
+  [Marc Foley]
+  * [Engineering] Fixed wrong characters appear in some mac apps. (LP: #1334363)
+
+
+2011-09-22 (Paul Sladen) Ubuntu Font Family version 0.80
+
+  [Vincent Connare/Dalton Maag]
+  * Wish for addition of a monospaced member to the family (LP: #640382)
+  * Mono: No hinting yet - Ubuntu Beta Mono font looks jagged in
+    Netbeans and terrible with ClearType (LP: #820493)
+  * Emacs: choosing normal monospace font in Emacs but gives bold-italic
+    (LP: #791076)
+  * PUA: ensure that Ubuntu Circle of Friends logo is full size: (LP: #853855)
+    + U+E0FF becomes large size in proportionals, remains small width in
+      monospaces
+    + U+F0FF becomes small size (proportionals only)
+    + U+F200 is full ubuntu logomark (proportionals only)
+
+  [Paul Sladen]
+  * Monospace: Patch Family Name to be "Ubuntu Mono"
+  * Monospace: Patch U+EFFD version debugging glyph to be '0.8'
+
+  [Cody Boisclair]
+  * Monospace: Force .null HDMX advance to 500
+  * Monospace: Remap ASCII box-drawing characters (LP: #788757)
+
+  [Júlio Reis]
+  * Date corrections to 'FONTLOG' (LP: #836595)
+
+2011-03-08 (Paul Sladen) Ubuntu Font Family version 0.71.2
+
+  * (Production) Adjust Medium WeightClass to 500 (Md, MdIt) (LP: #730912)
+
+2011-03-07 (Paul Sladen) Ubuntu Font Family version 0.71.1
+
+  * (Design) Add Capitalised version of glyphs and kern. (Lt, LtIt,
+    Md, MdIt) DM (LP: #677446)
+  * (Design) Re-space and tighen Regular and Italic by amount specified
+    by Mark Shuttleworth (minus 4 FUnits). (Rg, It) (LP: #677149)
+  * (Design) Design: Latin (U+0192) made straight more like l/c f with
+    tail (LP: #670768)
+  * (Design) (U+01B3) should have hook on right, as the lowercase
+    (U+01B4) (LP: #681026)
+  * (Design) Tail of Light Italic germandbls, longs and lowercase 'f'
+    to match Italic/BoldItalic (LP: #623925)
+  * (Production) Update <case> feature (Lt, LtIt, Md, MdIt). DM
+    (LP: #676538, #676539)
+  * (Production) Remove Bulgarian locl feature for Italics. (LP: #708578)
+  * (Production) Update Description information with new string:
+      "The Ubuntu Font Family are libre fonts funded by Canonical Ltd
+      on behalf of the Ubuntu project. The font design work and
+      technical implementation is being undertaken by Dalton Maag. The
+      typeface is sans-serif, uses OpenType features and is manually
+      hinted for clarity on desktop and mobile computing screens. The
+      scope of the Ubuntu Font Family includes all the languages used
+      by the various Ubuntu users around the world in tune with
+      Ubuntu's philosophy which states that every user should be able
+      to use their software in the language of their choice. The
+      project is ongoing, and we expect the family will be extended to
+      cover many written languages in the coming years."
+    (Rg, It, Bd, BdIt, Lt, LtIt, Md, MdIt) (LP: #690590)
+  * (Production) Pixel per em indicator added at U+F000 (Lt, LtIt, Md,
+    MdIt) (LP: #615787)
+  * (Production) Version number indicator added at U+EFFD (Lt, LtIt, Md,
+    MdIt) (LP: #640623)
+  * (Production) fstype bit set to 0 - Editable (Lt, LtIt, Md, MdIt)
+    (LP: #648406)
+  * (Production) Localisation of name table has been removed because
+    of problems with Mac OS/X interpretation of localisation. DM
+    (LP: #730785)
+  * (Hinting) Regular '?' dot non-circular (has incorrect control
+    value). (LP: #654336)
+  * (Hinting) Too much space after latin capital 'G' in 13pt
+    regular. Now reduced. (LP: #683437)
+  * (Hinting) Balance Indian Rupee at 18,19pt (LP: #662177)
+  * (Hinting) Make Regular '£' less ambiguous at 13-15 ppm (LP: #685562)
+  * (Hinting) Regular capital 'W' made symmetrical at 31 ppem (LP: #686168)
+
+2010-12-14 (Paul Sladen) Ubuntu Font Family version 0.70.1
+
+  Packaging, rebuilt from '2010-12-08 UbuntuFontsSourceFiles_070.zip':
+  * (Midstream) Fstype bit != 0 (LP: #648406)
+  * (Midstream) Add unit test to validate fstype bits (LP: #648406)
+  * (Midstream) Add unit test to validate licence
+
+2010-12-14 (Paul Sladen) Ubuntu Font Family version 0.70
+
+  Release notes 0.70:
+  * (Design) Add Capitalised version of glyphs and kern. (Rg, It, Bd,
+    BdIt) DM (LP: #676538, #677446)
+  * (Design) Give acute and grave a slight upright move to more match
+    the Hungarian double acute angle. (Rg, It, Bd, BdIt) (LP: #656647)
+  * (Design) Shift Bold Italic accent glyphs to be consistent with the
+    Italic. (BdIt only) DM (LP: #677449)
+  * (Design) Check spacing and kerning of dcaron, lcaron and
+    tcaron. (Rg, It, Bd, BdIt) (LP: #664722)
+  * (Design) Add positive kerning to () {} [] to open out the
+    combinations so they are less like a closed box. (Rg, It, Bd,
+    BdIt) (LP: #671228)
+  * (Design) Change design of acute.asc and check highest points (Bd
+    and BdIt only) DM
+  * (Production) Update <case> feature. DM (LP: #676538, #676539)
+  * (Production) Remove Romanian locl feature. (Rg, It, Bd, BdIt)
+    (LP: #635615)
+  * (Production) Update Copyright information with new
+    strings. "Copyright 2010 Canonical Ltd. Licensed under the Ubuntu
+    Font Licence 1.0" Trademark string "Ubuntu and Canonical are
+    registered trademarks of Canonical Ltd." (Rg, It, Bd, BdIt) DM
+    (LP: #677450)
+  * (Design) Check aligning of hyphen, math signs em, en, check braces
+    and other brackets. 16/11 (LP: #676465)
+  * (Production) Pixel per em indicator added at U+F000 (Rg, It, Bd,
+    BdIt) (LP: #615787)
+  * (Production) Version number indicator added at U+EFFD (Rg, It, Bd,
+    BdIt) (LP: #640623)
+  * (Production) fstype bit set to 0 - Editable (Rg, It, Bd, BdIt)
+    (LP: #648406)
+
+2010-10-05 (Paul Sladen) Ubuntu Font Family version 0.69
+
+  [Dalton Maag]
+  * Italic,
+    - Hinting on lowercase Italic l amended 19ppm (LP: #632451)
+    - Hinting on lowercase Italic u amended 12ppm (LP: #626376)
+
+  * Regular, Italic, Bold, BoldItalic
+    - New Rupee Sign added @ U+20B9 (LP: #645987)
+    - Ubuntu Roundel added @ U+E0FF (LP: #651606)
+
+  [Paul Sladen]
+  * All
+    - Removed "!ubu" GSUB.calt ligature for U+E0FF (LP: #651606)
+
+
+Acknowledgements
+
+If you make modifications be sure to add your name (N), email (E),
+web-address (if you have one) (W) and description (D). This list is in
+alphabetical order.
+
+N: Ryan Abdullah
+W: http://www.rayan.de/
+D: Arabic calligraphy and design in collaboration with Dalton Maag
+D: Arabic testing
+
+N: Cody Boisclair
+D: Monospace low-level debugging and patching ('fixboxdrawing-ft.py')
+
+N: Amélie Bonet
+W: http://ameliebonet.com/
+D: Type design with Dalton Maag, particularly Ubuntu Mono and Ubuntu Condensed
+
+N: Jason Campbell
+W: http://www.campbellgraphics.com/design/fonts.shtml
+D: Monospace hinting (first phase) at Dalton Maag
+
+N: Pilar Cano
+W: http://www.pilarcano.com/
+D: Hebrew realisation with Dalton Maag
+
+N: Fernando Caro  
+D: Type design with Dalton Maag, particularly Ubuntu Condensed
+
+N: Ron Carpenter
+W: http://www.daltonmaag.com/
+D: Type design with Dalton Maag
+D: Arabic realisation in collaboration with Ryan Abdullah
+
+N: Vincent Connare
+W: http://www.connare.com/
+D: Type design, and engineering with Dalton Maag
+D: Monospace hinting (second phase) at Dalton Maag
+
+N: Dave Crossland
+E: dave@understandingfonts.com
+W: http://understandingfonts.com/
+D: Documentation and libre licensing guidance
+D: Google Webfont integration at Google
+
+N: Steve Edwards
+W: http://www.madebymake.com/
+D: font.ubuntu.com revamp implementation with Canonical Web Team
+
+N: Iain Farrell
+W: http://www.flickr.com/photos/iain
+D: Ubuntu Font Family delivery for the Ubuntu UX team at Canonical
+
+N: Marc Foley
+W: http://www.marcfoley.co/
+D: Font Engineer at Dalton Maag for the 2015 updates
+
+N: Shiraaz Gabru
+W: http://www.daltonmaag.com/
+D: Ubuntu Font Family project management at Dalton Maag
+
+N: Marcus Haslam
+W: http://design.canonical.com/author/marcus-haslam/
+D: Creative inspiration
+
+N: Ben Laenen
+D: Inspiration behind the pixels-per-em (PPEM) readout debugging glyph at U+F000
+   (for this font the concept was re-implemented from scratch by Dalton-Maag)
+
+N: Bruno Maag
+W: http://www.daltonmaag.com/
+D: Stylistic direction of the Ubuntu Font Family, as head of Dalton Maag
+
+N: Ivanka Majic
+W: http://www.ivankamajic.com/
+D: Guiding the UX team and Cyrillic feedback
+
+N: David Marshall
+W: http://www.daltonmaag.com/
+D: Technical guidance and administration at Dalton Maag
+
+N: Malcolm Wooden
+W: http://www.daltonmaag.com/
+D: Font Engineering at Dalton Maag
+
+N: Lukas Paltram
+W: http://www.daltonmaag.com/
+D: Type design with Dalton Maag
+
+N: Júlio Reis
+D: Date fixes to the documentation
+
+N: Rodrigo Rivas
+D: Indian Rupee Sign glyph
+
+N: Mark Shuttleworth
+E: mark@ubuntu.com
+W: http://www.markshuttleworth.com/
+D: Executive quality-control and funding
+
+N: Paul Sladen
+E: ubuntu@paul.sladen.org
+W: http://www.paul.sladen.org/
+D: Bug triaging, packaging at Ubuntu and Canonical
+
+N: Nicolas Spalinger
+W: http://planet.open-fonts.org
+D: Continuous guidance on libre/open font licensing, best practises in source
+   tree layout, release and packaging (pkg-fonts Debian team)
+
+N: Kenneth Wimer
+D: Initial PPA packaging
+
+* Canonical Ltd is the primary commercial sponsor of the Ubuntu and
+  Kubuntu operating systems
+* Dalton Maag are a custom type foundry headed by Bruno Maag
+
+For further documentation, information on contributors, source code
+downloads and those involved with the Ubuntu Font Family, visit:
+
+  http://font.ubuntu.com/

--- a/lib/src/text/fonts/LICENCE-FAQ.txt
+++ b/lib/src/text/fonts/LICENCE-FAQ.txt
@@ -1,0 +1,177 @@
+                        Ubuntu Font Family Licensing FAQ
+
+  Stylistic Foundations
+
+   The Ubuntu Font Family is the first time that a libre typeface has been
+   designed professionally and explicitly with the intent of developing a
+   public and long-term community-based development process.
+
+   When developing an open project, it is generally necessary to have firm
+   foundations: a font needs to maintain harmony within itself even across
+   many type designers and writing systems. For the [1]Ubuntu Font Family,
+   the process has been guided with the type foundry Dalton Maag setting
+   the project up with firm stylistic foundation covering several
+   left-to-right scripts: Latin, Greek and Cyrillic; and right-to-left
+   scripts: Arabic and Hebrew (due in 2011).
+
+   With this starting point the community will, under the supervision of
+   [2]Canonical and [3]Dalton Maag, be able to build on the existing font
+   sources to expand their character coverage. Ultimately everybody will
+   be able to use the Ubuntu Font Family in their own written languages
+   across the whole of Unicode (and this will take some time!).
+
+  Licensing
+
+   The licence chosen by any free software project is one of the
+   foundational decisions that sets out how derivatives and contributions
+   can occur, and in turn what kind of community will form around the
+   project.
+
+   Using a licence that is compatible with other popular licences is a
+   powerful constraint because of the [4]network effects: the freedom to
+   share improvements between projects allows free software to reach
+   high-quality over time. Licence-proliferation leads to many
+   incompatible licences, undermining the network effect, the freedom to
+   share and ultimately making the libre movement that Ubuntu is a part of
+   less effective. For all kinds of software, writing a new licence is not
+   to be taken lightly and is a choice that needs to be thoroughly
+   justified if this path is taken.
+
+   Today it is not clear to Canonical what the best licence for a font
+   project like the Ubuntu Font Family is: one that starts life designed
+   by professionals and continues with the full range of community
+   development, from highly commercial work in new directions to curious
+   beginners' experimental contributions. The fast and steady pace of the
+   Ubuntu release cycle means that an interim libre licence has been
+   necessary to enable the consideration of the font family as part of
+   Ubuntu 10.10 operating system release.
+
+   Before taking any decision on licensing, Canonical as sponsor and
+   backer of the project has reviewed the many existing licenses used for
+   libre/open fonts and engaged the stewards of the most popular licenses
+   in detailed discussions. The current interim licence is the first step
+   in progressing the state-of-the-art in licensing for libre/open font
+   development.
+
+   The public discussion must now involve everyone in the (comparatively
+   new) area of the libre/open font community; including font users,
+   software freedom advocates, open source supporters and existing libre
+   font developers. Most importantly, the minds and wishes of professional
+   type designers considering entering the free software business
+   community must be taken on board.
+
+   Conversations and discussion has taken place, privately, with
+   individuals from the following groups (generally speaking personally on
+   behalf of themselves, rather than their affiliations):
+     * [5]SIL International
+     * [6]Open Font Library
+     * [7]Software Freedom Law Center
+     * [8]Google Font API
+
+    Document embedding
+
+   One issue highlighted early on in the survey of existing font licences
+   is that of document embedding. Almost all font licences, both free and
+   unfree, permit embedding a font into a document to a certain degree.
+   Embedding a font with other works that make up a document creates a
+   "combined work" and copyleft would normally require the whole document
+   to be distributed under the terms of the font licence. As beautiful as
+   the font might be, such a licence makes a font too restrictive for
+   useful general purpose digital publishing.
+
+   The situation is not entirely unique to fonts and is encountered also
+   with tools such as GNU Bison: a vanilla GNU GPL licence would require
+   anything generated with Bison to be made available under the terms of
+   the GPL as well. To avoid this, Bison is [9]published with an
+   additional permission to the GPL which allows the output of Bison to be
+   made available under any licence.
+
+   The conflict between licensing of fonts and licensing of documents, is
+   addressed in two popular libre font licences, the SIL OFL and GNU GPL:
+     * [10]SIL Open Font Licence: When OFL fonts are embedded in a
+       document, the OFL's terms do not apply to that document. (See
+       [11]OFL-FAQ for details.
+     * [12]GPL Font Exception: The situation is resolved by granting an
+       additional permission to allow documents to not be covered by the
+       GPL. (The exception is being reviewed).
+
+   The Ubuntu Font Family must also resolve this conflict, ensuring that
+   if the font is embedded and then extracted it is once again clearly
+   under the terms of its libre licence.
+
+    Long-term licensing
+
+   Those individuals involved, especially from Ubuntu and Canonical, are
+   interested in finding a long-term libre licence that finds broad favour
+   across the whole libre/open font community. The deliberation during the
+   past months has been on how to licence the Ubuntu Font Family in the
+   short-term, while knowingly encouraging everyone to pursue a long-term
+   goal.
+     * [13]Copyright assignment will be required so that the Ubuntu Font
+       Family's licensing can be progressively expanded to one (or more)
+       licences, as best practice continues to evolve within the
+       libre/open font community.
+     * Canonical will support and fund legal work on libre font licensing.
+       It is recognised that the cost and time commitments required are
+       likely to be significant. We invite other capable parties to join
+       in supporting this activity.
+
+   The GPL version 3 (GPLv3) will be used for Ubuntu Font Family build
+   scripts and the CC-BY-SA for associated documentation and non-font
+   content: all items which do not end up embedded in general works and
+   documents.
+
+Ubuntu Font Licence
+
+   For the short-term only, the initial licence is the [14]Ubuntu Font
+   License (UFL). This is loosely inspired from the work on the SIL
+   OFL 1.1, and seeks to clarify the issues that arose during discussions
+   and legal review, from the perspective of the backers, Canonical Ltd.
+   Those already using established licensing models such as the GPL, OFL
+   or Creative Commons licensing should have no worries about continuing
+   to use them. The Ubuntu Font Licence (UFL) and the SIL Open Font
+   Licence (SIL OFL) are not identical and should not be confused with
+   each other. Please read the terms precisely. The UFL is only intended
+   as an interim license, and the overriding aim is to support the
+   creation of a more suitable and generic libre font licence. As soon as
+   such a licence is developed, the Ubuntu Font Family will migrate to
+   it—made possible by copyright assignment in the interium. Between the
+   OFL 1.1, and the UFL 1.0, the following changes are made to produce the
+   Ubuntu Font Licence:
+     * Clarification:
+
+    1. Document embedding (see [15]embedding section above).
+    2. Apply at point of distribution, instead of receipt
+    3. Author vs. copyright holder disambiguation (type designers are
+       authors, with the copyright holder normally being the funder)
+    4. Define "Propagate" (for internationalisation, similar to the GPLv3)
+    5. Define "Substantially Changed"
+    6. Trademarks are explicitly not transferred
+    7. Refine renaming requirement
+
+     Streamlining:
+    8. Remove "not to be sold separately" clause
+    9. Remove "Reserved Font Name(s)" declaration
+
+   A visual demonstration of how these points were implemented can be
+   found in the accompanying coloured diff between SIL OFL 1.1 and the
+   Ubuntu Font Licence 1.0: [16]ofl-1.1-ufl-1.0.diff.html
+
+References
+
+   1. http://font.ubuntu.com/
+   2. http://www.canonical.com/
+   3. http://www.daltonmaag.com/
+   4. http://en.wikipedia.org/wiki/Network_effect
+   5. http://scripts.sil.org/
+   6. http://openfontlibrary.org/
+   7. http://www.softwarefreedom.org/
+   8. http://code.google.com/webfonts
+   9. http://www.gnu.org/licenses/gpl-faq.html#CanIUseGPLToolsForNF
+  10. http://scripts.sil.org/OFL_web
+  11. http://scripts.sil.org/OFL-FAQ_web
+  12. http://www.gnu.org/licenses/gpl-faq.html#FontException
+  13. https://launchpad.net/~uff-contributors
+  14. http://font.ubuntu.com/ufl/ubuntu-font-licence-1.0.txt
+  15. http://font.ubuntu.com/ufl/FAQ.html#embedding
+  16. http://font.ubuntu.com/ufl/ofl-1.1-ufl-1.0.diff.html

--- a/lib/src/text/fonts/LICENCE.txt
+++ b/lib/src/text/fonts/LICENCE.txt
@@ -1,0 +1,96 @@
+-------------------------------
+UBUNTU FONT LICENCE Version 1.0
+-------------------------------
+
+PREAMBLE
+This licence allows the licensed fonts to be used, studied, modified and
+redistributed freely. The fonts, including any derivative works, can be
+bundled, embedded, and redistributed provided the terms of this licence
+are met. The fonts and derivatives, however, cannot be released under
+any other licence. The requirement for fonts to remain under this
+licence does not require any document created using the fonts or their
+derivatives to be published under this licence, as long as the primary
+purpose of the document is not to be a vehicle for the distribution of
+the fonts.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this licence and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Original Version" refers to the collection of Font Software components
+as received under this licence.
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to
+a new environment.
+
+"Copyright Holder(s)" refers to all individuals and companies who have a
+copyright ownership of the Font Software.
+
+"Substantially Changed" refers to Modified Versions which can be easily
+identified as dissimilar to the Font Software by users of the Font
+Software comparing the Original Version with the Modified Version.
+
+To "Propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy. Propagation includes copying,
+distribution (with or without modification and with or without charging
+a redistribution fee), making available to the public, and in some
+countries other activities as well.
+
+PERMISSION & CONDITIONS
+This licence does not grant any rights under trademark law and all such
+rights are reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to propagate the Font Software, subject to
+the below conditions:
+
+1) Each copy of the Font Software must contain the above copyright
+notice and this licence. These can be included either as stand-alone
+text files, human-readable headers or in the appropriate machine-
+readable metadata fields within text or binary files as long as those
+fields can be easily viewed by the user.
+
+2) The font name complies with the following:
+(a) The Original Version must retain its name, unmodified.
+(b) Modified Versions which are Substantially Changed must be renamed to
+avoid use of the name of the Original Version or similar names entirely.
+(c) Modified Versions which are not Substantially Changed must be
+renamed to both (i) retain the name of the Original Version and (ii) add
+additional naming elements to distinguish the Modified Version from the
+Original Version. The name of such Modified Versions must be the name of
+the Original Version, with "derivative X" where X represents the name of
+the new work, appended to that name.
+
+3) The name(s) of the Copyright Holder(s) and any contributor to the
+Font Software shall not be used to promote, endorse or advertise any
+Modified Version, except (i) as required by this licence, (ii) to
+acknowledge the contribution(s) of the Copyright Holder(s) or (iii) with
+their explicit written permission.
+
+4) The Font Software, modified or unmodified, in part or in whole, must
+be distributed entirely under this licence, and must not be distributed
+under any other licence. The requirement for fonts to remain under this
+licence does not affect any document created using the Font Software,
+except any version of the Font Software extracted from a document
+created using the Font Software may only be distributed under this
+licence.
+
+TERMINATION
+This licence becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.

--- a/lib/src/text/fonts/README.txt
+++ b/lib/src/text/fonts/README.txt
@@ -1,0 +1,16 @@
+ ----------------------
+  Ubuntu Font Family
+ ======================
+
+The Ubuntu Font Family are a set of matching new libre/open fonts in
+development during 2010--2011.  And with further expansion work and
+bug fixing during 2015.  The development is being funded by
+Canonical Ltd on behalf the wider Free Software community and the
+Ubuntu project.  The technical font design work and implementation is
+being undertaken by Dalton Maag.
+
+Both the final font Truetype/OpenType files and the design files used
+to produce the font family are distributed under an open licence and
+you are expressly encouraged to experiment, modify, share and improve.
+
+  http://font.ubuntu.com/

--- a/lib/src/text/fonts/TRADEMARKS.txt
+++ b/lib/src/text/fonts/TRADEMARKS.txt
@@ -1,0 +1,4 @@
+Ubuntu and Canonical are registered trademarks of Canonical Ltd.
+
+The licence accompanying these works does not grant any rights
+under trademark law and all such rights are reserved.

--- a/lib/src/text/fonts/copyright.txt
+++ b/lib/src/text/fonts/copyright.txt
@@ -1,0 +1,5 @@
+Copyright 2010,2011 Canonical Ltd.
+
+This Font Software is licensed under the Ubuntu Font Licence, Version
+1.0.  https://launchpad.net/ubuntu-font-licence
+


### PR DESCRIPTION
The .txt files were extracted from `ubuntu-font-family-0.83.zip` downloaded from https://design.ubuntu.com/font.