### PR TITLE
Rename yaruMate to yaruUbuntuMate for consistency

### DIFF
--- a/lib/src/themes/ubuntu_mate.dart
+++ b/lib/src/themes/ubuntu_mate.dart
@@ -15,7 +15,10 @@ final _lightColorScheme = ColorScheme.fromSwatch(
   brightness: Brightness.light,
 );
 
-final yaruMateLight = createYaruLightTheme(
+@Deprecated('Use yaruUbuntuMateLight instead')
+final yaruMateLight = yaruUbuntuMateLight;
+
+final yaruUbuntuMateLight = createYaruLightTheme(
     colorScheme: _lightColorScheme, primaryColor: _primaryColor);
 
 final _darkColorScheme = ColorScheme.fromSwatch(
@@ -28,5 +31,8 @@ final _darkColorScheme = ColorScheme.fromSwatch(
   brightness: Brightness.dark,
 );
 
-final yaruMateDark = createYaruDarkTheme(
+@Deprecated('Use yaruUbuntuMateDark instead')
+final yaruMateDark = yaruUbuntuMateDark;
+
+final yaruUbuntuMateDark = createYaruDarkTheme(
     colorScheme: _darkColorScheme, primaryColor: _primaryColor);

--- a/lib/src/themes/variant.dart
+++ b/lib/src/themes/variant.dart
@@ -93,7 +93,7 @@ final _yaruLightThemes = <YaruVariant, ThemeData>{
   YaruVariant.kubuntuBlue: yaruKubuntuLight,
   YaruVariant.lubuntuBlue: yaruLubuntuLight,
   YaruVariant.ubuntuBudgieBlue: yaruUbuntuBudgieLight,
-  YaruVariant.ubuntuMateGreen: yaruMateLight,
+  YaruVariant.ubuntuMateGreen: yaruUbuntuMateLight,
   YaruVariant.ubuntuStudioBlue: yaruUbuntuStudioLight,
   YaruVariant.xubuntuBlue: yaruXubuntuLight,
 };
@@ -112,7 +112,7 @@ final _yaruDarkThemes = <YaruVariant, ThemeData>{
   YaruVariant.kubuntuBlue: yaruKubuntuDark,
   YaruVariant.lubuntuBlue: yaruLubuntuDark,
   YaruVariant.ubuntuBudgieBlue: yaruUbuntuBudgieDark,
-  YaruVariant.ubuntuMateGreen: yaruMateDark,
+  YaruVariant.ubuntuMateGreen: yaruUbuntuMateDark,
   YaruVariant.ubuntuStudioBlue: yaruUbuntuStudioDark,
   YaruVariant.xubuntuBlue: yaruXubuntuDark,
 };


### PR DESCRIPTION
To match other flavor variants, and its own color constant.

Flavor variants:
- yaruKubuntu
- yaruLubuntu
- yaruMate // <==
- yaruUbuntuBudgie
- yaruUbuntuStudio
- yaruXubuntu

Colors constants:
- yaruKubuntuBlue
- yaruLubuntuBlue
- yaruUbuntuBudgieBlue
- yaruUbuntuMateGreen // <==
- yaruUbuntuStudioBlue
- yaruXubuntuBlue