### PR TITLE
Enable flutter_lints/recommended and fix findings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:yaru/src/text/text_theme.dart';
 import 'package:yaru/src/colors/yaru_colors.dart';
+import 'package:yaru/src/text/text_theme.dart';
 import 'package:yaru/src/themes/constants.dart';
 
 // AppBar
@@ -18,7 +18,7 @@ AppBarTheme _createLightAppBar(ColorScheme colorScheme) {
       fontWeight: FontWeight.normal,
     ),
     iconTheme: IconThemeData(color: colorScheme.onSurface),
-    actionsIconTheme: IconThemeData(color: YaruColors.inkstone),
+    actionsIconTheme: const IconThemeData(color: YaruColors.inkstone),
   );
 }
 
@@ -44,7 +44,8 @@ final inputDecorationTheme = InputDecorationTheme(
 
 // Buttons
 
-final _commonButtonStyle = ButtonStyle(visualDensity: VisualDensity.standard);
+final _commonButtonStyle =
+    const ButtonStyle(visualDensity: VisualDensity.standard);
 
 final _buttonThemeData = ButtonThemeData(
   shape: RoundedRectangleBorder(
@@ -94,7 +95,7 @@ ElevatedButtonThemeData _getElevatedButtonThemeData(Color color) {
   ));
 }
 
-final _toggleButtonsTheme = ToggleButtonsThemeData(
+final _toggleButtonsTheme = const ToggleButtonsThemeData(
     borderRadius: BorderRadius.all(Radius.circular(kButtonRadius)));
 
 // Dialogs

--- a/lib/src/themes/variant.dart
+++ b/lib/src/themes/variant.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:yaru/src/colors/flavor_colors.dart';
 import 'package:yaru/src/colors/yaru_colors.dart';
 import 'package:yaru/src/themes/kubuntu.dart';
-import 'package:yaru/src/themes/yaru.dart';
 import 'package:yaru/src/themes/lubuntu.dart';
 import 'package:yaru/src/themes/ubuntu_budgie.dart';
 import 'package:yaru/src/themes/ubuntu_mate.dart';
 import 'package:yaru/src/themes/ubuntu_studio.dart';
 import 'package:yaru/src/themes/xubuntu.dart';
+import 'package:yaru/src/themes/yaru.dart';
 
 /// Describes a Yaru variant and its primary color.
 class YaruVariant {

--- a/lib/src/widgets/inherited_theme.dart
+++ b/lib/src/widgets/inherited_theme.dart
@@ -109,7 +109,7 @@ class _YaruThemeState extends State<YaruTheme> {
     if (name == 'Yaru') {
       return YaruVariant.orange;
     }
-    for (var value in YaruVariant.values) {
+    for (final value in YaruVariant.values) {
       if (value.name.toLowerCase() == name.toLowerCase()) {
         return value;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.10
+  flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
   mockito: ^5.1.0

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -59,7 +59,7 @@ void main() {
       expect(YaruTheme.of(context).variant, YaruVariant.blue);
 
       when(settings.get('gtk-theme'))
-          .thenAnswer((_) async => DBusString('Yaru-red'));
+          .thenAnswer((_) async => const DBusString('Yaru-red'));
       keysChanged.add(['gtk-theme']);
       await tester.pump();
       expect(YaruTheme.of(context).variant, YaruVariant.red);
@@ -155,7 +155,7 @@ void main() {
 
 MockGSettings createMockGSettings({String theme = ''}) {
   final settings = MockGSettings();
-  when(settings.keysChanged).thenAnswer((_) => Stream.empty());
+  when(settings.keysChanged).thenAnswer((_) => const Stream.empty());
   when(settings.get('gtk-theme')).thenAnswer((_) async => DBusString(theme));
   return settings;
 }


### PR DESCRIPTION
Enable `prefer_const_constructors` to ensure that `const` is used whenever possible.