### PR TITLE
Add successColor and warningColor extensions for ThemeData

### DIFF
--- a/lib/src/themes/extensions.dart
+++ b/lib/src/themes/extensions.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:yaru_colors/yaru_colors.dart';
+
+/// Yaru-specific theming extensions.
+extension YaruThemeDataExtension on ThemeData {
+  /// A color to indicate success e.g. for text input validation.
+  ///
+  /// ```dart
+  /// Theme.of(context).successColor
+  /// ```
+  ///
+  /// See also:
+  ///  * [ThemeData.errorColor]
+  Color get successColor => YaruColors.success;
+
+  /// A color to indicate warnings.
+  ///
+  /// This is the counterpart of [ThemeData.errorColor].
+  ///
+  /// ```dart
+  /// Theme.of(context).warningColor
+  /// ```
+  ///
+  /// See also:
+  ///  * [ThemeData.errorColor]
+  Color get warningColor => YaruColors.warning;
+}

--- a/lib/yaru.dart
+++ b/lib/yaru.dart
@@ -1,6 +1,7 @@
 library yaru;
 
 export 'package:yaru/src/themes/common_themes.dart';
+export 'package:yaru/src/themes/extensions.dart';
 export 'package:yaru/src/themes/high_contrast.dart';
 export 'package:yaru/src/themes/kubuntu.dart';
 export 'package:yaru/src/themes/lubuntu.dart';


### PR DESCRIPTION
This is just syntactic sugar to have YaruColors.success and .warning
counterparts for Theme.of(context).errorColor.

```dart
Column(
  children: [
    Text('Error', style: TextStyle(color: Theme.of(context).errorColor)),
    Text('Warning', style: TextStyle(color: Theme.of(context).warningColor)),
    Text('Success', style: TextStyle(color: Theme.of(context).successColor)),
  ],
),
```