### PR TITLE
Relax dbus version constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  dbus: ^0.7.3
+  dbus: ^0.7.0
   flutter:
     sdk: flutter
   gsettings: ^0.2.5


### PR DESCRIPTION
Lowering the version constraint increases compatibility with most other
D-Bus based packages that depend on ^0.7.0, which is fine because Yaru
doesn't specifically need the very latest version that was automatically
inserted by tooling.