### PR TITLE
Add text selection theme

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -36,11 +36,19 @@ AppBarTheme _createDarkAppBarTheme(ColorScheme colorScheme) {
   );
 }
 
+// TextField
 final inputDecorationTheme = InputDecorationTheme(
   border:
       OutlineInputBorder(borderRadius: BorderRadius.circular(kButtonRadius)),
   isDense: true,
 );
+
+TextSelectionThemeData _createTextSelectionTheme(ColorScheme colorScheme) {
+  return TextSelectionThemeData(
+    cursorColor: colorScheme.primary,
+    selectionColor: colorScheme.primary.withOpacity(0.40),
+  );
+}
 
 // Buttons
 
@@ -240,6 +248,7 @@ ThemeData createYaruLightTheme(
     ),
     inputDecorationTheme: inputDecorationTheme,
     toggleButtonsTheme: _toggleButtonsTheme,
+    textSelectionTheme: _createTextSelectionTheme(colorScheme),
   );
 }
 
@@ -284,5 +293,6 @@ ThemeData createYaruDarkTheme(
     ),
     inputDecorationTheme: inputDecorationTheme,
     toggleButtonsTheme: _toggleButtonsTheme,
+    textSelectionTheme: _createTextSelectionTheme(colorScheme),
   );
 }


### PR DESCRIPTION
Flutter master has introduced a `DefaultSelectionStyle` widget that is
by default provided from MaterialApp. If no TextSelectionTheme is set in
the current theme context, TextField gets the default style that ends up
using the primary color from MaterialApp's theme data. This is not well
compatible with the newly added YaruTheme widget, which is created as a
child of MaterialApp. Providing the desired TextSelectionTheme avoids
that TextField would "bypass" YaruTheme.

Fixes: #160