### PR TITLE
CI: build the example to catch build issues

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Check for any analyzer issues
       run: flutter analyze .
 
+    - name: Install dependencies
+      run: sudo apt install clang cmake curl ninja-build libgtk-3-dev pkg-config unzip
+
     - name: Build example
       run: flutter build linux -v
       working-directory: example/

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -32,3 +32,7 @@ jobs:
     
     - name: Check for any analyzer issues
       run: flutter analyze .
+
+    - name: Build example
+      run: flutter build linux -v
+      working-directory: example/

--- a/linux/yaru_plugin.cc
+++ b/linux/yaru_plugin.cc
@@ -6,6 +6,8 @@
 #define YARU_PLUGIN(obj) \
   (G_TYPE_CHECK_INSTANCE_CAST((obj), yaru_plugin_get_type(), YaruPlugin))
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(YaruPlugin, g_object_unref)
+
 struct _YaruPlugin {
   GObject parent_instance;
   gint theme_name_changed_id;


### PR DESCRIPTION
Includes a fix to the following build issue that slipped in in #193:

    yaru_plugin.cc:92:3: error: use of undeclared identifier 'glib_autoptr_cleanup_YaruPlugin'