### PR TITLE
Page transitions consistency on desktop platforms

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -241,9 +241,13 @@ RadioThemeData _getRadioThemeData(Color primaryColor, Brightness brightness) {
   );
 }
 
+const _desktopPageTransitionsBuilder = CupertinoPageTransitionsBuilder();
+
 const _pageTransitionTheme = PageTransitionsTheme(
   builders: {
-    TargetPlatform.linux: CupertinoPageTransitionsBuilder(),
+    TargetPlatform.linux: _desktopPageTransitionsBuilder,
+    TargetPlatform.macOS: _desktopPageTransitionsBuilder,
+    TargetPlatform.windows: _desktopPageTransitionsBuilder,
   },
 );
 

--- a/test/common_themes_test.dart
+++ b/test/common_themes_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/foundation.dart';
+import 'package:yaru/src/themes/yaru.dart';
+
+void main() {
+  testWidgets('consistent page transitions', (_) async {
+    const platforms = [
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+      TargetPlatform.windows,
+    ];
+    final builders = yaruLight.pageTransitionsTheme.builders;
+    final first = builders.entries.first.value;
+    var allEqual = false;
+
+    for (var entry in builders.entries) {
+      if (platforms.contains(entry.key)) {
+        allEqual = entry.value == first;
+      }
+    }
+    expect(allEqual, isTrue);
+  });
+}


### PR DESCRIPTION
Fixes #202 by applying the common page transitions builder on the current desktop platforms supported by Flutter.