### PR TITLE
Introduce theme data overrides

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
+  collection: ^1.16.0
   flutter:
     sdk: flutter
   platform: ^3.1.0

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -149,6 +149,24 @@ void main() {
       expect(YaruTheme.of(context).themeMode, ThemeMode.dark);
     });
   });
+
+  testWidgets('theme data overrides', (tester) async {
+    const extensions = <ThemeExtension>[];
+    const pageTransitionsTheme = PageTransitionsTheme();
+    const visualDensity = VisualDensity(horizontal: -4, vertical: -4);
+    await tester.pumpTheme(
+      extensions: extensions,
+      pageTransitionsTheme: pageTransitionsTheme,
+      useMaterial3: false,
+      visualDensity: visualDensity,
+    );
+    final context = tester.element(find.byType(Container));
+    final theme = YaruTheme.of(context);
+    expect(theme.extensions, same(extensions));
+    expect(theme.pageTransitionsTheme, same(pageTransitionsTheme));
+    expect(theme.useMaterial3, isFalse);
+    expect(theme.visualDensity, visualDensity);
+  });
 }
 
 MockYaruSettings createMockSettings({String theme = ''}) {
@@ -163,6 +181,10 @@ extension ThemeTester on WidgetTester {
     YaruVariant? variant,
     bool? highContrast,
     ThemeMode? themeMode,
+    Iterable<ThemeExtension<dynamic>>? extensions,
+    PageTransitionsTheme? pageTransitionsTheme,
+    bool? useMaterial3,
+    VisualDensity? visualDensity,
     String desktop = '',
     YaruSettings? settings,
   }) async {
@@ -170,6 +192,10 @@ extension ThemeTester on WidgetTester {
       variant: variant,
       highContrast: highContrast,
       themeMode: themeMode,
+      extensions: extensions,
+      pageTransitionsTheme: pageTransitionsTheme,
+      useMaterial3: useMaterial3,
+      visualDensity: visualDensity,
     );
     await pumpWidget(
       MaterialApp(


### PR DESCRIPTION
Allow overriding a few `ThemeData` aspects when using the `YaruTheme` convenience widget. For example, the following code overrides the default page transitions and visual density:

```dart
YaruTheme(
  data: YaruThemeData(
   pageTransitionsTheme: PageTransitionsTheme(/*...*/),
   visualDensity: VisualDensity(horizontal: -4, vertical: -4),
 ),
  builder: (context, yaru, child) {
    return MaterialApp(
      theme: yaru.theme,
      darkTheme: yaru.darkTheme,
      home: ...
    );
  },
)
```

This paves the road for introducing alternative page transitions for wizard and master-detail apps (#184).