### PR TITLE
Use G_DECLARE_FINAL_TYPE to fix build with flutter-snap

### DIFF
--- a/linux/include/yaru/yaru_plugin.h
+++ b/linux/include/yaru/yaru_plugin.h
@@ -11,10 +11,7 @@ G_BEGIN_DECLS
 #define FLUTTER_PLUGIN_EXPORT
 #endif
 
-typedef struct _YaruPlugin YaruPlugin;
-typedef struct {
-  GObjectClass parent_class;
-} YaruPluginClass;
+G_DECLARE_FINAL_TYPE(YaruPlugin, yaru_plugin, YARU, PLUGIN, GObject)
 
 FLUTTER_PLUGIN_EXPORT GType yaru_plugin_get_type();
 

--- a/linux/yaru_plugin.cc
+++ b/linux/yaru_plugin.cc
@@ -3,11 +3,6 @@
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
 
-#define YARU_PLUGIN(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj), yaru_plugin_get_type(), YaruPlugin))
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(YaruPlugin, g_object_unref)
-
 struct _YaruPlugin {
   GObject parent_instance;
   gint theme_name_changed_id;


### PR DESCRIPTION
The Clang version in the core18-based flutter-snap is not happy with `G_DEFINE_AUTOPTR_CLEANUP_FUNC`. Using `G_DECLARE_FINAL_TYPE` gives autoptr support in a way that makes it happy.

Fixes: #210