### PR TITLE
Dark AppBar: make border bright

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -28,7 +28,7 @@ AppBarTheme _createLightAppBar(ColorScheme colorScheme) {
 
 AppBarTheme _createDarkAppBarTheme(ColorScheme colorScheme) {
   return AppBarTheme(
-    shadowColor: colorScheme.background,
+    shadowColor: colorScheme.onSurface.withOpacity(0.2),
     scrolledUnderElevation: kAppBarElevation,
     surfaceTintColor: colorScheme.background,
     toolbarHeight: kAppBarHeight,


### PR DESCRIPTION
|before|after|
|-|-|
|![grafik](https://user-images.githubusercontent.com/15329494/195279009-f393dadc-93f9-4f65-9394-d5f3c331df2a.png)|![grafik](https://user-images.githubusercontent.com/15329494/195278868-86b4e88d-891a-4bd4-84b3-d2dd876feef0.png)|

I've gone with the onSurface.withOpacity(0.2) as It is a bit softer than the divider color.
WDYT @Jupi007 @jpnurmi ?