### PR TITLE
Fix AppBar border

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -9,7 +9,9 @@ import 'package:yaru_colors/yaru_colors.dart';
 
 AppBarTheme _createLightAppBar(ColorScheme colorScheme) {
   return AppBarTheme(
-    shadowColor: colorScheme.onSurface,
+    shape: Border(
+      bottom: BorderSide(color: colorScheme.onSurface.withOpacity(0.2)),
+    ),
     scrolledUnderElevation: kAppBarElevation,
     surfaceTintColor: colorScheme.background,
     toolbarHeight: kAppBarHeight,
@@ -28,7 +30,9 @@ AppBarTheme _createLightAppBar(ColorScheme colorScheme) {
 
 AppBarTheme _createDarkAppBarTheme(ColorScheme colorScheme) {
   return AppBarTheme(
-    shadowColor: colorScheme.onSurface.withOpacity(0.2),
+    shape: Border(
+      bottom: BorderSide(color: colorScheme.onSurface.withOpacity(0.2)),
+    ),
     scrolledUnderElevation: kAppBarElevation,
     surfaceTintColor: colorScheme.background,
     toolbarHeight: kAppBarHeight,

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -3,6 +3,6 @@ import 'dart:ui';
 const kButtonRadius = 6.0;
 const kCheckRadius = 3.0;
 const kWindowRadius = 8.0;
-const kAppBarElevation = 1.0;
+const kAppBarElevation = 0.0;
 const kAppBarHeight = 48.0;
 const kDisabledGreyDark = Color(0xFF535353);


### PR DESCRIPTION
Draw it as a border rather than a 1px elevated shadow to get consistent results regardless of the platform and renderer.

| Dark | Light |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/197420697-f4c826c7-9822-435d-bc56-676d934f0712.png) | ![image](https://user-images.githubusercontent.com/140617/197420728-a7fdfc9c-6666-44fc-a36c-5f08236a9ace.png) |