### PR TITLE
Add missing light dialog theme background color

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -137,20 +137,19 @@ ToggleButtonsThemeData _createToggleButtonsTheme(ColorScheme colorScheme) {
 
 // Dialogs
 
-final _dialogThemeDark = DialogTheme(
-  backgroundColor: YaruColors.coolGrey,
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(kWindowRadius),
-    side: BorderSide(color: Colors.white.withOpacity(0.2)),
-  ),
-);
-
-final _dialogThemeLight = DialogTheme(
-  backgroundColor: YaruColors.porcelain,
-  shape: RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(kWindowRadius),
-  ),
-);
+DialogTheme _createDialogTheme(Brightness brightness) {
+  return DialogTheme(
+    backgroundColor: brightness == Brightness.dark
+        ? YaruColors.coolGrey
+        : YaruColors.porcelain,
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(kWindowRadius),
+      side: brightness == Brightness.dark
+          ? BorderSide(color: Colors.white.withOpacity(0.2))
+          : BorderSide.none,
+    ),
+  );
+}
 
 // Switches
 
@@ -270,7 +269,7 @@ ThemeData createYaruLightTheme({
     pageTransitionsTheme: YaruPageTransitionsTheme.horizontal,
     useMaterial3: useMaterial3,
     tabBarTheme: TabBarTheme(labelColor: colorScheme.onSurface),
-    dialogTheme: _dialogThemeLight,
+    dialogTheme: _createDialogTheme(Brightness.light),
     brightness: Brightness.light,
     primaryColor: colorScheme.primary,
     canvasColor: colorScheme.background,
@@ -320,7 +319,7 @@ ThemeData createYaruDarkTheme({
     pageTransitionsTheme: YaruPageTransitionsTheme.horizontal,
     useMaterial3: useMaterial3,
     tabBarTheme: TabBarTheme(labelColor: Colors.white.withOpacity(0.8)),
-    dialogTheme: _dialogThemeDark,
+    dialogTheme: _createDialogTheme(Brightness.dark),
     brightness: Brightness.dark,
     primaryColor: colorScheme.primary,
     canvasColor: colorScheme.background,

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -146,6 +146,7 @@ final _dialogThemeDark = DialogTheme(
 );
 
 final _dialogThemeLight = DialogTheme(
+  backgroundColor: YaruColors.porcelain,
   shape: RoundedRectangleBorder(
     borderRadius: BorderRadius.circular(kWindowRadius),
   ),


### PR DESCRIPTION
## Before

[before.webm](https://user-images.githubusercontent.com/140617/209817539-3bd897af-5759-433f-b05e-e7935a8e0c96.webm)

## After

[after.webm](https://user-images.githubusercontent.com/140617/209817585-251a1b69-618d-4d13-b1de-3e1e835ba15b.webm)

Fixes: #222