### PR TITLE
Disable theme variant detection in tests

### DIFF
--- a/lib/src/widgets/inherited_theme.dart
+++ b/lib/src/widgets/inherited_theme.dart
@@ -149,7 +149,7 @@ class _YaruThemeState extends State<YaruTheme> {
   @override
   void initState() {
     super.initState();
-    if (widget.data.variant == null && !kIsWeb && widget._platform.isLinux) {
+    if (widget.data.variant == null && canDetectVariant()) {
       _settings = widget._settings ?? const YaruSettings();
       updateVariant().then((_) {
         _subscription = _settings!.themeNameChanged.listen(updateVariant);
@@ -161,6 +161,12 @@ class _YaruThemeState extends State<YaruTheme> {
   void dispose() {
     _subscription?.cancel();
     super.dispose();
+  }
+
+  bool canDetectVariant() {
+    return !kIsWeb &&
+        widget._platform.isLinux &&
+        !widget._platform.environment.containsKey('FLUTTER_TEST');
   }
 
   // "Yaru-prussiangreen-dark" => YaruAccent.prussianGreen
@@ -183,7 +189,7 @@ class _YaruThemeState extends State<YaruTheme> {
   }
 
   Future<void> updateVariant([String? value]) async {
-    assert(!kIsWeb && widget._platform.isLinux);
+    assert(canDetectVariant());
     final name = value ?? await _settings?.getThemeName();
     setState(() => _variant = resolveVariant(name));
   }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -18,6 +18,12 @@ void main() {
     expect(YaruTheme.of(context).variant, YaruVariant.blue);
   });
 
+  testWidgets('flutter test', (tester) async {
+    await tester.pumpTheme(environment: {'FLUTTER_TEST': '1'});
+    final context = tester.element(find.byType(Container));
+    expect(YaruTheme.of(context).variant, isNull);
+  });
+
   group('gtk-theme', () {
     testWidgets('unknown', (tester) async {
       final settings = createMockSettings(theme: '');
@@ -193,6 +199,7 @@ extension ThemeTester on WidgetTester {
     VisualDensity? visualDensity,
     String desktop = '',
     YaruSettings? settings,
+    Map<String, String>? environment,
   }) async {
     final data = YaruThemeData(
       variant: variant,
@@ -211,7 +218,10 @@ extension ThemeTester on WidgetTester {
           data: data,
           platform: FakePlatform(
             operatingSystem: Platform.linux,
-            environment: {'XDG_CURRENT_DESKTOP': desktop},
+            environment: {
+              'XDG_CURRENT_DESKTOP': desktop,
+              ...?environment,
+            },
           ),
           settings: settings,
         ),


### PR DESCRIPTION
Building an empty SizedBox instead of the actual application is bad for testing. Check if `FLUTTER_TEST` environment variable is set.

Fixes: canonical/ubuntu-desktop-installer#1278