### PR TITLE
Dark theme borders: reduce opacity

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -31,7 +31,7 @@ AppBarTheme _createLightAppBar(ColorScheme colorScheme) {
 AppBarTheme _createDarkAppBarTheme(ColorScheme colorScheme) {
   return AppBarTheme(
     shape: Border(
-      bottom: BorderSide(color: colorScheme.onSurface.withOpacity(0.2)),
+      bottom: BorderSide(color: colorScheme.onSurface.withOpacity(0.07)),
     ),
     scrolledUnderElevation: kAppBarElevation,
     surfaceTintColor: colorScheme.background,
@@ -326,7 +326,7 @@ ThemeData createYaruDarkTheme({
     scaffoldBackgroundColor: colorScheme.background,
     bottomAppBarColor: colorScheme.surface,
     cardColor: colorScheme.surface,
-    dividerColor: colorScheme.onSurface.withOpacity(0.12),
+    dividerColor: colorScheme.onSurface.withOpacity(0.07),
     backgroundColor: colorScheme.background,
     dialogBackgroundColor: colorScheme.background,
     errorColor: colorScheme.error,


### PR DESCRIPTION
This reduces the strength of dividers and the appbar border in the dark theme

Before:
![grafik](https://user-images.githubusercontent.com/15329494/211167618-94d29be2-74d0-4b63-9562-2217821a241b.png)


After:
![grafik](https://user-images.githubusercontent.com/15329494/211167605-f8f23820-905f-437e-a21a-4dd14aeef1a1.png)
