### PR TITLE
Adjust TextField content padding

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -54,6 +54,7 @@ InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
     ),
     isDense: true,
     iconColor: colorScheme.onSurface,
+    contentPadding: const EdgeInsets.all(12),
   );
 }
 


### PR DESCRIPTION
To match the height of buttons by default. Notice that this only works with the default font size. For example, there's a tiny difference between the two after turning on the large text accessibility setting.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/211575233-71132ff3-38b2-4c4d-be66-84a8771f765b.png) | ![image](https://user-images.githubusercontent.com/140617/211575121-815eda3d-0ff4-4d82-84a7-eaf9d2563940.png) |
| ![Screenshot from 2023-01-10 15-05-09](https://user-images.githubusercontent.com/140617/211574858-4c9f1695-d1a3-430a-a106-5513b4c19e70.png) | ![Screenshot from 2023-01-10 15-05-21](https://user-images.githubusercontent.com/140617/211574870-8232d3fc-9639-4043-848e-472a057018ef.png) |