### PR TITLE
Reduce AppBar height

### DIFF
--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -4,5 +4,5 @@ const kButtonRadius = 6.0;
 const kCheckRadius = 3.0;
 const kWindowRadius = 8.0;
 const kAppBarElevation = 0.0;
-const kAppBarHeight = 48.0;
+const kAppBarHeight = 47.0;
 const kDisabledGreyDark = Color(0xFF535353);


### PR DESCRIPTION
From 48 to 47 to match with YaruTitleBar & GtkHeaderBar.

Fixes: ubuntu/yaru_widgets.dart#502