### PR TITLE
CI: no need to run tests when publishing to GH pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
-      - run: flutter pub get
-      - run: flutter test
       - uses: bluefireteam/flutter-gh-pages@v7
         with:
           workingDir: example


### PR DESCRIPTION
It's already done by the flutter-ci/test job.