### PR TITLE
Bump minimum Flutter version to 3.7.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/ubuntu/yaru.dart
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.7.0"
 
 dependencies:
   collection: ^1.16.0


### PR DESCRIPTION
We are already using new properties introduced in 3.7.0.
```
  error • The named parameter 'surfaceTintColor' isn't defined • lib/src/themes/common_themes.dart:187:5 • undefined_named_parameter
  error • The named parameter 'outlineVariant' isn't defined • lib/src/themes/common_themes.dart:353:19 • undefined_named_parameter
  error • The named parameter 'outlineVariant' isn't defined • lib/src/themes/common_themes.dart:407:19 • undefined_named_parameter
  error • The named parameter 'surfaceTintColor' isn't defined • lib/src/themes/common_themes.dart:420:5 • undefined_named_parameter
```

This makes sure the user is clearly notified if they try to use the latest version with an older version of Flutter:
```
The current Flutter SDK version is 3.3.10.

Because yaru_example depends on yaru from path which requires Flutter SDK version >=3.7.0, version solving failed.
```