### PR TITLE
Brighten up some accent colors in the dark theme

### DIFF
--- a/example/lib/view/home_page.dart
+++ b/example/lib/view/home_page.dart
@@ -69,13 +69,9 @@ class HomePageState extends State<HomePage> {
         ),
         actions: [
           PopupMenuButton<Color>(
-            onSelected: (value) {},
-            child: SizedBox(
-              width: 40,
-              child: Icon(
-                Icons.color_lens,
-                color: Theme.of(context).primaryColor,
-              ),
+            icon: Icon(
+              Icons.color_lens,
+              color: Theme.of(context).primaryColor,
             ),
             itemBuilder: (context) {
               return [

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -371,12 +371,12 @@ ThemeData createYaruLightTheme({
     error: YaruColors.error,
     brightness: Brightness.light,
     primary: primaryColor,
-    onPrimary: Colors.white,
+    onPrimary: contrastColor(primaryColor),
     primaryContainer: YaruColors.porcelain,
     onPrimaryContainer: YaruColors.inkstone,
     inversePrimary: YaruColors.inkstone,
     secondary: elevatedButtonColor ?? primaryColor,
-    onSecondary: Colors.white,
+    onSecondary: contrastColor(elevatedButtonColor ?? primaryColor),
     secondaryContainer:
         elevatedButtonColor?.withOpacity(0.4) ?? primaryColor.withOpacity(0.4),
     onSecondaryContainer: elevatedButtonTextColor ?? YaruColors.jet,
@@ -443,7 +443,7 @@ ThemeData createYaruLightTheme({
     appBarTheme: _createLightAppBar(colorScheme),
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: elevatedButtonColor ?? primaryColor,
-      foregroundColor: elevatedButtonTextColor ?? Colors.white,
+      foregroundColor: contrastColor(elevatedButtonColor ?? primaryColor),
     ),
     bottomNavigationBarTheme: BottomNavigationBarThemeData(
       selectedItemColor: colorScheme.primary,
@@ -467,7 +467,7 @@ ThemeData createYaruLightTheme({
     ),
     badgeTheme: BadgeThemeData(
       backgroundColor: elevatedButtonColor ?? colorScheme.primary,
-      textColor: elevatedButtonTextColor ?? Colors.white,
+      textColor: contrastColor(elevatedButtonColor ?? primaryColor),
     ),
   );
 }
@@ -486,11 +486,11 @@ ThemeData createYaruDarkTheme({
     brightness: Brightness.dark,
     primary: primaryColor,
     primaryContainer: YaruColors.coolGrey,
-    onPrimary: YaruColors.porcelain,
+    onPrimary: contrastColor(primaryColor),
     onPrimaryContainer: YaruColors.porcelain,
     inversePrimary: YaruColors.porcelain,
     secondary: elevatedButtonColor ?? primaryColor,
-    onSecondary: Colors.white,
+    onSecondary: contrastColor(elevatedButtonColor ?? primaryColor),
     secondaryContainer:
         elevatedButtonColor?.withOpacity(0.4) ?? primaryColor.withOpacity(0.4),
     onSecondaryContainer:
@@ -559,7 +559,7 @@ ThemeData createYaruDarkTheme({
     appBarTheme: _createDarkAppBarTheme(colorScheme),
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: elevatedButtonColor ?? primaryColor,
-      foregroundColor: elevatedButtonTextColor ?? Colors.white,
+      foregroundColor: contrastColor(elevatedButtonColor ?? primaryColor),
     ),
     bottomNavigationBarTheme: BottomNavigationBarThemeData(
       selectedItemColor: colorScheme.primary,
@@ -582,10 +582,17 @@ ThemeData createYaruDarkTheme({
     ),
     badgeTheme: BadgeThemeData(
       backgroundColor: elevatedButtonColor ?? colorScheme.primary,
-      textColor: elevatedButtonTextColor ?? Colors.white,
+      textColor: contrastColor(elevatedButtonColor ?? primaryColor),
     ),
   );
 }
+
+Color contrastColor(Color color) => ThemeData.estimateBrightnessForColor(
+          color,
+        ) ==
+        Brightness.light
+    ? Colors.black
+    : Colors.white;
 
 PopupMenuThemeData _createPopupMenuThemeData(
   ColorScheme colorScheme,

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -165,10 +165,7 @@ ElevatedButtonThemeData _getElevatedButtonThemeData({
   return ElevatedButtonThemeData(
     style: ElevatedButton.styleFrom(
       backgroundColor: color,
-      foregroundColor: textColor ??
-          (ThemeData.estimateBrightnessForColor(color) == Brightness.light
-              ? Colors.black
-              : Colors.white),
+      foregroundColor: textColor ?? contrastColor(color),
       visualDensity: _commonButtonStyle.visualDensity,
       elevation: 0,
       shadowColor: Colors.transparent,

--- a/lib/src/themes/xubuntu.dart
+++ b/lib/src/themes/xubuntu.dart
@@ -8,5 +8,5 @@ final yaruXubuntuLight = createYaruLightTheme(
 );
 
 final yaruXubuntuDark = createYaruDarkTheme(
-  primaryColor: _primaryColor,
+  primaryColor: _primaryColor.shade500,
 );

--- a/lib/src/themes/yaru.dart
+++ b/lib/src/themes/yaru.dart
@@ -18,7 +18,7 @@ final yaruSageLight = createYaruLightTheme(
 );
 
 final yaruSageDark = createYaruDarkTheme(
-  primaryColor: YaruColors.sage,
+  primaryColor: YaruColors.sage.shade500,
 );
 
 final yaruPrussianGreenLight = createYaruLightTheme(

--- a/lib/src/themes/yaru.dart
+++ b/lib/src/themes/yaru.dart
@@ -42,7 +42,7 @@ final yaruBarkLight = createYaruLightTheme(
 );
 
 final yaruBarkDark = createYaruDarkTheme(
-  primaryColor: YaruColors.bark,
+  primaryColor: YaruColors.bark.shade500,
 );
 
 final yaruViridianLight = createYaruLightTheme(


### PR DESCRIPTION
using shade500 for xubuntublue, bark and sage

those colors are generally quite unsaturated and thus need to be lightened up in the dark theme to guarantee good contrast. But this means that white does not work on them anymore. Thus using (ThemeData.estimateBrightnessForColor(color) == Brightness.light
              ? Colors.black
              : Colors.white) instead

<img width="829" alt="Bildschirm­foto 2023-01-28 um 22 31 30" src="https://user-images.githubusercontent.com/15329494/215292112-3d199c9b-7c45-49ec-b373-32a5ca9727c7.png">

<img width="829" alt="Bildschirm­foto 2023-01-28 um 22 32 01" src="https://user-images.githubusercontent.com/15329494/215292125-f3d5cc66-9218-4379-a4df-cbf93a6ed5b7.png">

<img width="829" alt="Bildschirm­foto 2023-01-28 um 22 33 24" src="https://user-images.githubusercontent.com/15329494/215292162-cf547843-0eab-4550-a8e4-efb8694bce02.png">

Fixes #267