### PR TITLE
Light theme: surface and background got incorrectly switched in 0.5.0

### DIFF
--- a/example/lib/view/containers_view.dart
+++ b/example/lib/view/containers_view.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+class ContainersView extends StatefulWidget {
+  const ContainersView({super.key});
+
+  @override
+  State<ContainersView> createState() => _ContainersViewState();
+}
+
+class _ContainersViewState extends State<ContainersView> {
+  var _elevation = 2.0;
+
+  @override
+  Widget build(BuildContext context) {
+    var card = Row(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Card(
+            elevation: _elevation,
+            child: const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 100, vertical: 50),
+              child: Text('Card'),
+            ),
+          ),
+        ),
+      ],
+    );
+    var slider = Row(
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 10),
+          child: Text(_elevation.toStringAsFixed(2)),
+        ),
+        Slider(
+          value: _elevation,
+          max: 10,
+          min: 0,
+          onChanged: (value) => setState(() => _elevation = value),
+        ),
+      ],
+    );
+
+    var containerWithBorder = Row(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(12.0),
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: Theme.of(context).colorScheme.outline),
+            ),
+            child: const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 70, vertical: 50),
+              child: Text('Just a border'),
+            ),
+          ),
+        )
+      ],
+    );
+
+    return ListView(
+      children: [
+        card,
+        slider,
+        const Divider(),
+        containerWithBorder,
+        const Divider(),
+        Padding(
+          padding: const EdgeInsets.only(left: 40, top: 10),
+          child: Text(
+            'Dialog',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+        ),
+        Row(
+          children: [
+            SimpleDialog(
+              shadowColor: Colors.black,
+              children: [
+                card,
+                slider,
+                containerWithBorder,
+              ],
+            ),
+          ],
+        )
+      ],
+    );
+  }
+}

--- a/example/lib/view/controls_view.dart
+++ b/example/lib/view/controls_view.dart
@@ -10,6 +10,15 @@ class ControlsView extends StatefulWidget {
 class _ControlsViewState extends State<ControlsView>
     with TickerProviderStateMixin {
   late TabController tabController;
+  int _counter = 0;
+
+  void incrementCounter() {
+    setState(() {
+      _counter++;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Yay! $_counter ❤️ for Yaru')));
+    });
+  }
 
   @override
   void initState() {
@@ -144,6 +153,17 @@ class _ControlsViewState extends State<ControlsView>
                             ),
                           ],
                         ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(
+                        children: [
+                          FloatingActionButton(
+                            onPressed: () => {incrementCounter()},
+                            child: const Icon(Icons.plus_one),
+                          ),
+                        ],
                       ),
                     ),
                     Padding(

--- a/example/lib/view/home_page.dart
+++ b/example/lib/view/home_page.dart
@@ -3,6 +3,7 @@ import 'package:yaru/yaru.dart';
 import 'package:yaru_example/main.dart';
 import 'package:yaru_example/view/color_disk.dart';
 import 'package:yaru_example/view/colors_view.dart';
+import 'package:yaru_example/view/containers_view.dart';
 import 'package:yaru_example/view/controls_view.dart';
 import 'package:yaru_example/view/fonts_view.dart';
 import 'package:yaru_example/view/inputs_view.dart';
@@ -16,15 +17,6 @@ class HomePage extends StatefulWidget {
 
 class HomePageState extends State<HomePage> {
   HomePageState();
-  int _counter = 0;
-
-  void incrementCounter() {
-    setState(() {
-      _counter++;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Yay! $_counter ❤️ for Yaru')));
-    });
-  }
 
   final textController = TextEditingController(
     text:
@@ -36,7 +28,8 @@ class HomePageState extends State<HomePage> {
     const FontsView(),
     const ControlsView(),
     InputsView(),
-    const ColorsView()
+    const ColorsView(),
+    const ContainersView()
   ];
 
   @override
@@ -144,6 +137,11 @@ class HomePageState extends State<HomePage> {
                       icon: Icon(Icons.color_lens_outlined),
                       selectedIcon: Icon(Icons.color_lens),
                       label: Text('Palette'),
+                    ),
+                    NavigationRailDestination(
+                      icon: Icon(Icons.square_outlined),
+                      selectedIcon: Icon(Icons.square),
+                      label: Text('Containers'),
                     )
                   ],
                   selectedIndex: _selectedIndex,
@@ -190,7 +188,12 @@ class HomePageState extends State<HomePage> {
                       icon: Icon(Icons.color_lens_outlined),
                       selectedIcon: Icon(Icons.color_lens),
                       label: 'Palette',
-                    )
+                    ),
+                    NavigationDestination(
+                      icon: Icon(Icons.square_outlined),
+                      selectedIcon: Icon(Icons.square),
+                      label: 'Containers',
+                    ),
                   ],
                   selectedIndex: _selectedIndex,
                   onDestinationSelected: (index) =>
@@ -201,11 +204,6 @@ class HomePageState extends State<HomePage> {
           }
         },
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => {incrementCounter()},
-        child: const Icon(Icons.plus_one),
-      ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
     );
   }
 }

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -16,11 +16,11 @@ AppBarTheme _createLightAppBar(ColorScheme colorScheme) {
       bottom: BorderSide(color: colorScheme.onSurface.withOpacity(0.2)),
     ),
     scrolledUnderElevation: kAppBarElevation,
-    surfaceTintColor: colorScheme.background,
+    surfaceTintColor: colorScheme.surface,
     toolbarHeight: kAppBarHeight,
     elevation: kAppBarElevation,
     systemOverlayStyle: SystemUiOverlayStyle.light,
-    backgroundColor: colorScheme.background,
+    backgroundColor: colorScheme.surface,
     foregroundColor: colorScheme.onSurface,
     titleTextStyle: createTextTheme(YaruColors.inkstone).titleLarge!.copyWith(
           color: colorScheme.onSurface,
@@ -121,27 +121,21 @@ final _buttonThemeData = ButtonThemeData(
   ),
 );
 
-final _outlinedButtonThemeData = OutlinedButtonThemeData(
-  style: OutlinedButton.styleFrom(
-    side: const BorderSide(color: Colors.black38, width: 0.3),
-    visualDensity: _commonButtonStyle.visualDensity,
-    foregroundColor: YaruColors.textGrey,
-    shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.circular(kButtonRadius),
+OutlinedButtonThemeData _createOutlinedButtonThemeData(
+  ColorScheme colorScheme,
+) {
+  return OutlinedButtonThemeData(
+    style: OutlinedButton.styleFrom(
+      side: BorderSide(color: colorScheme.outline),
+      visualDensity: _commonButtonStyle.visualDensity,
+      // backgroundColor: colorScheme.surface, // defaults to transparent
+      foregroundColor: colorScheme.onSurface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(kButtonRadius),
+      ),
     ),
-  ),
-);
-
-final _darkOutlinedButtonThemeData = OutlinedButtonThemeData(
-  style: OutlinedButton.styleFrom(
-    side: const BorderSide(color: Colors.white38, width: 0.3),
-    shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.circular(kButtonRadius),
-    ),
-    visualDensity: _commonButtonStyle.visualDensity,
-    foregroundColor: Colors.white,
-  ),
-);
+  );
+}
 
 TextButtonThemeData _createTextButtonThemeData(
   ColorScheme colorScheme,
@@ -197,8 +191,9 @@ FilledButtonThemeData _getFilledButtonThemeData(
 ToggleButtonsThemeData _createToggleButtonsTheme(ColorScheme colorScheme) {
   return ToggleButtonsThemeData(
     borderRadius: const BorderRadius.all(Radius.circular(kButtonRadius)),
+    borderColor: colorScheme.outline,
     selectedColor: colorScheme.onSurface,
-    fillColor: colorScheme.onSurface.withOpacity(.15),
+    fillColor: colorScheme.outline,
     hoverColor: colorScheme.onSurface.withOpacity(.05),
   );
 }
@@ -377,9 +372,9 @@ ThemeData createYaruLightTheme({
     secondaryContainer:
         elevatedButtonColor?.withOpacity(0.4) ?? primaryColor.withOpacity(0.4),
     onSecondaryContainer: elevatedButtonTextColor ?? YaruColors.jet,
-    background: Colors.white,
+    background: YaruColors.porcelain,
     onBackground: YaruColors.inkstone,
-    surface: YaruColors.porcelain,
+    surface: Colors.white,
     onSurface: YaruColors.inkstone,
     inverseSurface: YaruColors.jet,
     onInverseSurface: YaruColors.porcelain,
@@ -424,7 +419,7 @@ ThemeData createYaruLightTheme({
     indicatorColor: colorScheme.secondary,
     applyElevationOverlayColor: false,
     buttonTheme: _buttonThemeData,
-    outlinedButtonTheme: _outlinedButtonThemeData,
+    outlinedButtonTheme: _createOutlinedButtonThemeData(colorScheme),
     elevatedButtonTheme: _getElevatedButtonThemeData(
       color: elevatedButtonColor ?? primaryColor,
       textColor: elevatedButtonTextColor,
@@ -548,7 +543,7 @@ ThemeData createYaruDarkTheme({
       color: elevatedButtonColor ?? primaryColor,
       textColor: elevatedButtonTextColor,
     ),
-    outlinedButtonTheme: _darkOutlinedButtonThemeData,
+    outlinedButtonTheme: _createOutlinedButtonThemeData(colorScheme),
     switchTheme: _getSwitchThemeData(colorScheme, Brightness.dark),
     checkboxTheme: _getCheckBoxThemeData(colorScheme, Brightness.dark),
     radioTheme: _getRadioThemeData(colorScheme, Brightness.dark),
@@ -662,8 +657,8 @@ NavigationBarThemeData _createNavigationBarTheme(
   Brightness brightness,
 ) {
   return NavigationBarThemeData(
-    backgroundColor: colorScheme.background,
-    surfaceTintColor: colorScheme.background,
+    backgroundColor: colorScheme.surface,
+    surfaceTintColor: colorScheme.surface,
     indicatorColor: colorScheme.onSurface.withOpacity(0.1),
     iconTheme: MaterialStateProperty.resolveWith(
       (states) => states.contains(MaterialState.selected)
@@ -678,7 +673,7 @@ NavigationRailThemeData _createNavigationRailTheme(
   Brightness brightness,
 ) {
   return NavigationRailThemeData(
-    backgroundColor: colorScheme.background,
+    backgroundColor: colorScheme.surface,
     indicatorColor: colorScheme.onSurface.withOpacity(0.1),
     selectedIconTheme: IconThemeData(color: colorScheme.onSurface),
     unselectedIconTheme: IconThemeData(


### PR DESCRIPTION
Light theme:

- switch surface and background color like they were before 0.5.0
![grafik](https://user-images.githubusercontent.com/15329494/215461175-ad1f4abe-4a78-4168-9cee-0103f2a029c6.png)
![grafik](https://user-images.githubusercontent.com/15329494/215461430-bb025751-5886-4974-b371-d0d318ac667b.png)

- needs adaptions to the light appbar to make it look like before
- needs unification of the outlined buttons to just use outline color like dividers

Example:
- added another view for "container" like widgets and dialogs, can be improved further
- moved the FAP to the controls view as it is always in the way with the current column (content|navbar) layout. It works better if you just use scaffold but since the example switches layouts this is not possible


Fixes #269