### PR TITLE
Regenerate package metadata

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -1,30 +1,10 @@
 # This file tracks properties of this Flutter project.
 # Used by Flutter tool to assess capabilities and perform upgrades etc.
 #
-# This file should be version controlled.
+# This file should be version controlled and should not be manually edited.
 
 version:
-  revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
+  revision: b06b8b2710955028a6b562f5aa6fe62941d6febf
   channel: stable
 
-project_type: plugin
-
-# Tracks metadata for the flutter migrate command
-migration:
-  platforms:
-    - platform: root
-      create_revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
-      base_revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
-    - platform: linux
-      create_revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
-      base_revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
-
-  # User provided section
-
-  # List of Local paths (relative to this file) that should be
-  # ignored by the migrate tool.
-  #
-  # Files that are not part of the templates will be ignored by default.
-  unmanaged_files:
-    - 'lib/main.dart'
-    - 'ios/Runner.xcodeproj/project.pbxproj'
+project_type: package


### PR DESCRIPTION
The metadata claimed that this was a plugin that only supports Linux. I've regenerated it with `flutter create --template package` to tell Dart and Flutter tooling that this is a plain cross-platform Dart package.

Fixes: #246 (hopefully)