### PR TITLE
Relax Flutter version constraint to allow beta

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/ubuntu/yaru.dart
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.7.0"
+  flutter: ">=3.7.0-0"
 
 dependencies:
   collection: ^1.16.0


### PR DESCRIPTION
The current version of the beta channel is 3.7.0-1.5.pre i.e. it's still a pre-release version of 3.7.0 even though it's good enough for yaru because it contains all the API we depend on.

```
The current Flutter SDK version is 3.7.0-1.5.pre.

Because yaru requires Flutter SDK version >=3.7.0, version solving failed.
```