### PR TITLE
FAB colors have too high contrast

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -353,12 +353,22 @@ ProgressIndicatorThemeData _createProgressIndicatorTheme(
 
 FloatingActionButtonThemeData _getFloatingActionButtonThemeData(
   ColorScheme colorScheme,
-) =>
-    FloatingActionButtonThemeData(
-      backgroundColor: colorScheme.inverseSurface,
-      foregroundColor: colorScheme.onInverseSurface,
-      shape: const CircleBorder(),
-    );
+  Brightness brightness,
+) {
+  final light = brightness == Brightness.light;
+  const elevation = 3.0;
+
+  return FloatingActionButtonThemeData(
+    backgroundColor: colorScheme.surface.scale(lightness: light ? -0.10 : 0.20),
+    foregroundColor: colorScheme.onSurface,
+    shape: const CircleBorder(),
+    elevation: elevation,
+    focusElevation: elevation,
+    hoverElevation: elevation,
+    disabledElevation: elevation,
+    highlightElevation: elevation,
+  );
+}
 
 /// Helper function to create a new Yaru light theme
 ThemeData createYaruLightTheme({
@@ -442,7 +452,8 @@ ThemeData createYaruLightTheme({
     checkboxTheme: _getCheckBoxThemeData(colorScheme, Brightness.light),
     radioTheme: _getRadioThemeData(colorScheme, Brightness.light),
     appBarTheme: _createLightAppBar(colorScheme),
-    floatingActionButtonTheme: _getFloatingActionButtonThemeData(colorScheme),
+    floatingActionButtonTheme:
+        _getFloatingActionButtonThemeData(colorScheme, Brightness.light),
     bottomNavigationBarTheme: BottomNavigationBarThemeData(
       selectedItemColor: colorScheme.primary,
       unselectedItemColor: colorScheme.onSurface.withOpacity(0.8),
@@ -555,7 +566,8 @@ ThemeData createYaruDarkTheme({
     radioTheme: _getRadioThemeData(colorScheme, Brightness.dark),
     primaryColorDark: primaryColor,
     appBarTheme: _createDarkAppBarTheme(colorScheme),
-    floatingActionButtonTheme: _getFloatingActionButtonThemeData(colorScheme),
+    floatingActionButtonTheme:
+        _getFloatingActionButtonThemeData(colorScheme, Brightness.dark),
     bottomNavigationBarTheme: BottomNavigationBarThemeData(
       selectedItemColor: colorScheme.primary,
       unselectedItemColor: Colors.white.withOpacity(0.8),


### PR DESCRIPTION
| | Before | After
| --- | --- | --- 
| Light | ![Capture d’écran du 2023-02-18 19-25-40](https://user-images.githubusercontent.com/36476595/219882270-f47248e4-36de-4ffc-946a-377d06b7b3ff.png) | ![Capture d’écran du 2023-02-18 19-42-52](https://user-images.githubusercontent.com/36476595/219882897-6b2d99fd-6e0b-44ff-bbbd-e24e6c549c9b.png)
| Dark | ![Capture d’écran du 2023-02-18 19-25-35](https://user-images.githubusercontent.com/36476595/219882258-f50ac402-c55b-4237-8639-7474b81d7b94.png) | ![Capture d’écran du 2023-02-18 19-42-56](https://user-images.githubusercontent.com/36476595/219882896-7ec11e21-5d21-41cf-abea-2f52397a3dcd.png)

I also set the same elevation for all states, because I thought it was weird to have both background highlight and increased elevation:

**Before:**

[Capture vidéo du 2023-02-18 19-32-27.webm](https://user-images.githubusercontent.com/36476595/219882549-0f47504a-3f19-441a-b276-e67090c18ad3.webm)

**After:**

[Capture vidéo du 2023-02-18 19-43-20.webm](https://user-images.githubusercontent.com/36476595/219882885-b800c63d-53b4-4ce0-942f-52ecf863134d.webm)

Fixes #281

CC @madsrh @anasereijo @jpnurmi 