### PR TITLE
Separate outline and divider colors

### DIFF
--- a/example/lib/view/containers_view.dart
+++ b/example/lib/view/containers_view.dart
@@ -48,7 +48,7 @@ class _ContainersViewState extends State<ContainersView> {
           child: Container(
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(10),
-              border: Border.all(color: Theme.of(context).colorScheme.outline),
+              border: Border.all(color: Theme.of(context).dividerColor),
             ),
             child: const Padding(
               padding: EdgeInsets.symmetric(horizontal: 70, vertical: 50),

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -59,7 +59,7 @@ InputDecorationTheme _createInputDecorationTheme(
   final light = brightness == Brightness.light;
   final fill =
       light ? const Color(0xFFededed) : const Color.fromARGB(255, 40, 40, 40);
-  final border = light ? kDividerColorLight : kDividerColorDark;
+  final border = colorScheme.outline;
   final disabledBorder = light
       ? const Color.fromARGB(255, 237, 237, 237)
       : const Color.fromARGB(255, 67, 67, 67);
@@ -259,9 +259,7 @@ Color _getSwitchTrackColor(
     if (states.contains(MaterialState.selected)) {
       return colorScheme.primary;
     } else {
-      return brightness == Brightness.dark
-          ? kDividerColorDark
-          : kDividerColorLight;
+      return colorScheme.outline;
     }
   }
 }
@@ -401,7 +399,7 @@ ThemeData createYaruLightTheme({
     tertiaryContainer: const Color(0xFF18b6ec),
     onTertiaryContainer: Colors.white,
     onSurfaceVariant: YaruColors.coolGrey,
-    outline: kDividerColorLight,
+    outline: const Color(0xFFCBCBCB),
     scrim: Colors.black,
   );
 
@@ -514,7 +512,7 @@ ThemeData createYaruDarkTheme({
     tertiaryContainer: const Color(0xFF18b6ec),
     onTertiaryContainer: YaruColors.porcelain,
     onSurfaceVariant: YaruColors.warmGrey,
-    outline: kDividerColorDark,
+    outline: const Color(0xFF585858),
     scrim: Colors.black,
   );
   return ThemeData.from(


### PR DESCRIPTION
- divider color can stay as it is
- make outline color more pronounced

![grafik](https://user-images.githubusercontent.com/15329494/220558411-8614bdae-aa18-4851-910d-5833b3e8a533.png)

![grafik](https://user-images.githubusercontent.com/15329494/220557095-5156b746-1a37-46c2-a964-90415f5c633b.png)

(1) Divider color, (2) Outline color

Ref #244 