### PR TITLE
Use filled buttons with a grey fill and an outline

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -173,6 +173,7 @@ FilledButtonThemeData _createFilledButtonThemeData(
 ) {
   return FilledButtonThemeData(
     style: FilledButton.styleFrom(
+      disabledBackgroundColor: colorScheme.onSurface.withOpacity(0.06),
       backgroundColor: colorScheme.onSurface.withOpacity(0.05),
       surfaceTintColor: colorScheme.onSurface.withOpacity(0.05),
       foregroundColor: colorScheme.onSurface,

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -168,18 +168,19 @@ ElevatedButtonThemeData _getElevatedButtonThemeData({
   );
 }
 
-FilledButtonThemeData _getFilledButtonThemeData(
-  Color backgroundColor,
-  Color foregroundColor,
+FilledButtonThemeData _createFilledButtonThemeData(
+  ColorScheme colorScheme,
 ) {
   return FilledButtonThemeData(
     style: FilledButton.styleFrom(
-      backgroundColor: backgroundColor.withOpacity(0.3),
-      foregroundColor: foregroundColor,
+      backgroundColor: colorScheme.onSurface.withOpacity(0.05),
+      surfaceTintColor: colorScheme.onSurface.withOpacity(0.05),
+      foregroundColor: colorScheme.onSurface,
       visualDensity: _commonButtonStyle.visualDensity,
       elevation: 0,
       shadowColor: Colors.transparent,
       shape: RoundedRectangleBorder(
+        side: BorderSide(color: colorScheme.outline),
         borderRadius: BorderRadius.circular(kButtonRadius),
       ),
     ),
@@ -438,9 +439,8 @@ ThemeData createYaruLightTheme({
       color: elevatedButtonColor ?? primaryColor,
       textColor: elevatedButtonTextColor,
     ),
-    filledButtonTheme: _getFilledButtonThemeData(
-      elevatedButtonColor ?? primaryColor,
-      colorScheme.onSurface,
+    filledButtonTheme: _createFilledButtonThemeData(
+      colorScheme,
     ),
     textButtonTheme: _createTextButtonThemeData(colorScheme),
     switchTheme: _getSwitchThemeData(colorScheme, Brightness.light),
@@ -547,9 +547,8 @@ ThemeData createYaruDarkTheme({
     applyElevationOverlayColor: true,
     buttonTheme: _buttonThemeData,
     textButtonTheme: _createTextButtonThemeData(colorScheme),
-    filledButtonTheme: _getFilledButtonThemeData(
-      elevatedButtonColor ?? primaryColor,
-      colorScheme.onSurface,
+    filledButtonTheme: _createFilledButtonThemeData(
+      colorScheme,
     ),
     elevatedButtonTheme: _getElevatedButtonThemeData(
       color: elevatedButtonColor ?? primaryColor,


### PR DESCRIPTION
Since we do not use tonal buttons currently in our apps this looks like the safest approach to me to not change elavated buttons everywhere.

- use a soft grey tint as the fill for filled buttons
- use outline color in an outline around the buttons

![grafik](https://user-images.githubusercontent.com/15329494/220615086-cde23ef3-781e-4117-a63f-04fe1b8c8259.png)

![grafik](https://user-images.githubusercontent.com/15329494/220615061-faf7b1f7-9f8b-4e8d-964b-19358f433059.png)

Ref #244 