### PR TITLE
Example: attempt to clarify the buttons

### DIFF
--- a/example/lib/view/controls_view.dart
+++ b/example/lib/view/controls_view.dart
@@ -67,14 +67,40 @@ class _ControlsViewState extends State<ControlsView>
                             width: 95,
                             child: TextButton(
                               onPressed: () {},
-                              child: const Text('Click me!'),
+                              child: const Text('Text'),
                             ),
                           ),
                           const SizedBox(width: 15),
-                          const TextButton(
-                            onPressed: null,
-                            autofocus: true,
-                            child: Text("Can't click me!"),
+                          const SizedBox(
+                            width: 95,
+                            child: TextButton(
+                              onPressed: null,
+                              autofocus: true,
+                              child: Text('Disabled'),
+                            ),
+                          ),
+                          const Spacer(),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(
+                        children: <Widget>[
+                          SizedBox(
+                            width: 95,
+                            child: OutlinedButton(
+                              onPressed: () {},
+                              child: const Text('Outlined'),
+                            ),
+                          ),
+                          const SizedBox(width: 15),
+                          const SizedBox(
+                            width: 95,
+                            child: OutlinedButton(
+                              onPressed: null,
+                              child: Text('Disabled'),
+                            ),
                           ),
                         ],
                       ),
@@ -83,14 +109,20 @@ class _ControlsViewState extends State<ControlsView>
                       padding: const EdgeInsets.all(8.0),
                       child: Row(
                         children: <Widget>[
-                          OutlinedButton(
-                            onPressed: () {},
-                            child: const Text('Click me!'),
+                          SizedBox(
+                            width: 95,
+                            child: FilledButton(
+                              onPressed: () {},
+                              child: const Text('Filled'),
+                            ),
                           ),
                           const SizedBox(width: 15),
-                          const OutlinedButton(
-                            onPressed: null,
-                            child: Text("Can't click me!"),
+                          const SizedBox(
+                            width: 95,
+                            child: FilledButton(
+                              onPressed: null,
+                              child: Text('Disabled'),
+                            ),
                           ),
                         ],
                       ),
@@ -99,30 +131,20 @@ class _ControlsViewState extends State<ControlsView>
                       padding: const EdgeInsets.all(8.0),
                       child: Row(
                         children: <Widget>[
-                          FilledButton(
-                            onPressed: () {},
-                            child: const Text('Click me!'),
+                          SizedBox(
+                            width: 95,
+                            child: ElevatedButton(
+                              onPressed: () {},
+                              child: const Text('Elevated'),
+                            ),
                           ),
                           const SizedBox(width: 15),
-                          const FilledButton(
-                            onPressed: null,
-                            child: Text("Can't click me!"),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Row(
-                        children: <Widget>[
-                          ElevatedButton(
-                            onPressed: () {},
-                            child: const Text('Click me!'),
-                          ),
-                          const SizedBox(width: 15),
-                          const ElevatedButton(
-                            onPressed: null,
-                            child: Text("Can't click me!"),
+                          const SizedBox(
+                            width: 95,
+                            child: ElevatedButton(
+                              onPressed: null,
+                              child: Text('Disabled'),
+                            ),
                           ),
                         ],
                       ),


### PR DESCRIPTION
A minor tweak to help the user understand what they're looking at.

| Before | After |
|---|---|
| ![Screenshot from 2023-02-27 10-10-06](https://user-images.githubusercontent.com/140617/221525252-60452ace-4f05-45cd-a0c3-05c0b1a8277c.png) | ![Screenshot from 2023-02-27 10-25-48](https://user-images.githubusercontent.com/140617/221525264-bf9efef2-2eec-4e51-9e4e-414260370b42.png) |
