### PR TITLE
TextTheme: add missing headlineLarge and labelMedium

### DIFF
--- a/lib/src/text/text_theme.dart
+++ b/lib/src/text/text_theme.dart
@@ -19,6 +19,11 @@ TextTheme createTextTheme(Color textColor) {
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),
+    headlineLarge: _UbuntuTextStyle(
+      fontSize: 40,
+      fontWeight: FontWeight.normal,
+      textColor: textColor,
+    ),
     headlineMedium: _UbuntuTextStyle(
       fontSize: 34,
       fontWeight: FontWeight.normal,
@@ -60,15 +65,21 @@ TextTheme createTextTheme(Color textColor) {
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),
+    bodySmall: _UbuntuTextStyle(
+      fontSize: 12,
+      letterSpacing: 0.4,
+      fontWeight: FontWeight.normal,
+      textColor: textColor,
+    ),
     labelLarge: _UbuntuTextStyle(
       fontSize: 14,
       letterSpacing: 0.25,
       fontWeight: FontWeight.w500,
       textColor: textColor,
     ),
-    bodySmall: _UbuntuTextStyle(
+    labelMedium: _UbuntuTextStyle(
       fontSize: 12,
-      letterSpacing: 0.4,
+      letterSpacing: 0.25,
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),


### PR DESCRIPTION
Not sure what the correct letter spacing values are. @Feichtmeier?

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/222072607-2155b27d-7e35-4c63-b6de-79445aad490a.png) | ![image](https://user-images.githubusercontent.com/140617/222071933-3cf79486-2612-4194-97c6-4d4a68bdb4ed.png) |

Fixes: #295