### PR TITLE
Sync light and dark themes

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -446,6 +446,7 @@ ThemeData createYaruLightTheme({
     switchTheme: _getSwitchThemeData(colorScheme, Brightness.light),
     checkboxTheme: _getCheckBoxThemeData(colorScheme, Brightness.light),
     radioTheme: _getRadioThemeData(colorScheme, Brightness.light),
+    primaryColorDark: null,
     appBarTheme: _createLightAppBar(colorScheme),
     floatingActionButtonTheme:
         _getFloatingActionButtonThemeData(colorScheme, Brightness.light),
@@ -526,12 +527,11 @@ ThemeData createYaruDarkTheme({
         surfaceTintColor: colorScheme.background,
       ),
     ),
-    progressIndicatorTheme:
-        _createProgressIndicatorTheme(colorScheme, Brightness.dark),
     iconTheme: IconThemeData(color: colorScheme.onSurface),
     primaryIconTheme: IconThemeData(color: colorScheme.onSurface),
+    progressIndicatorTheme:
+        _createProgressIndicatorTheme(colorScheme, Brightness.dark),
     pageTransitionsTheme: YaruPageTransitionsTheme.horizontal,
-    useMaterial3: useMaterial3,
     tabBarTheme:
         _createTabBarTheme(colorScheme, Brightness.dark, kDividerColorDark),
     dialogTheme: _createDialogTheme(Brightness.dark),
@@ -546,15 +546,15 @@ ThemeData createYaruDarkTheme({
     indicatorColor: colorScheme.primary,
     applyElevationOverlayColor: true,
     buttonTheme: _buttonThemeData,
-    textButtonTheme: _createTextButtonThemeData(colorScheme),
-    filledButtonTheme: _createFilledButtonThemeData(
-      colorScheme,
-    ),
+    outlinedButtonTheme: _createOutlinedButtonThemeData(colorScheme),
     elevatedButtonTheme: _getElevatedButtonThemeData(
       color: elevatedButtonColor ?? primaryColor,
       textColor: elevatedButtonTextColor,
     ),
-    outlinedButtonTheme: _createOutlinedButtonThemeData(colorScheme),
+    filledButtonTheme: _createFilledButtonThemeData(
+      colorScheme,
+    ),
+    textButtonTheme: _createTextButtonThemeData(colorScheme),
     switchTheme: _getSwitchThemeData(colorScheme, Brightness.dark),
     checkboxTheme: _getCheckBoxThemeData(colorScheme, Brightness.dark),
     radioTheme: _getRadioThemeData(colorScheme, Brightness.dark),


### PR DESCRIPTION
No visual changes, just moving the lines around for easier side-by-side comparison. Alphabetical order would be nice but I chose to keep the changes to the minimum.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/224128311-a0b7db01-0122-489a-bc99-b4188d7290f6.png) | ![image](https://user-images.githubusercontent.com/140617/224127068-7f3b74e8-cb9b-4300-a00b-4e594ce4b765.png) |
