### PR TITLE
Pass brightness to `_createAppBarTheme()`

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -10,43 +10,29 @@ const kDividerColorLight = Color(0xffdcdcdc);
 
 // AppBar
 
-AppBarTheme _createLightAppBar(ColorScheme colorScheme) {
+AppBarTheme _createAppBarTheme(ColorScheme colorScheme, Brightness brightness) {
   return AppBarTheme(
     shape: Border(
-      bottom: BorderSide(color: colorScheme.onSurface.withOpacity(0.2)),
+      bottom: BorderSide(
+        color: colorScheme.onSurface
+            .withOpacity(brightness == Brightness.light ? 0.2 : 0.07),
+      ),
     ),
     scrolledUnderElevation: kAppBarElevation,
     surfaceTintColor: colorScheme.surface,
     toolbarHeight: kAppBarHeight,
     elevation: kAppBarElevation,
-    systemOverlayStyle: SystemUiOverlayStyle.light,
+    systemOverlayStyle: brightness == Brightness.light
+        ? SystemUiOverlayStyle.light
+        : SystemUiOverlayStyle.dark,
     backgroundColor: colorScheme.surface,
     foregroundColor: colorScheme.onSurface,
-    titleTextStyle: createTextTheme(YaruColors.inkstone).titleLarge!.copyWith(
+    titleTextStyle: createTextTheme(colorScheme.onSurface).titleLarge!.copyWith(
           color: colorScheme.onSurface,
           fontWeight: FontWeight.normal,
         ),
     iconTheme: IconThemeData(color: colorScheme.onSurface),
-    actionsIconTheme: const IconThemeData(color: YaruColors.inkstone),
-  );
-}
-
-AppBarTheme _createDarkAppBarTheme(ColorScheme colorScheme) {
-  return AppBarTheme(
-    shape: Border(
-      bottom: BorderSide(color: colorScheme.onSurface.withOpacity(0.07)),
-    ),
-    scrolledUnderElevation: kAppBarElevation,
-    surfaceTintColor: colorScheme.background,
-    toolbarHeight: kAppBarHeight,
-    elevation: kAppBarElevation,
-    systemOverlayStyle: SystemUiOverlayStyle.dark,
-    backgroundColor: colorScheme.surface,
-    foregroundColor: colorScheme.onSurface,
-    titleTextStyle: createTextTheme(YaruColors.porcelain).titleLarge!.copyWith(
-          color: colorScheme.onSurface,
-          fontWeight: FontWeight.normal,
-        ),
+    actionsIconTheme: IconThemeData(color: colorScheme.onSurface),
   );
 }
 
@@ -447,7 +433,7 @@ ThemeData createYaruLightTheme({
     checkboxTheme: _getCheckBoxThemeData(colorScheme, Brightness.light),
     radioTheme: _getRadioThemeData(colorScheme, Brightness.light),
     primaryColorDark: null,
-    appBarTheme: _createLightAppBar(colorScheme),
+    appBarTheme: _createAppBarTheme(colorScheme, Brightness.light),
     floatingActionButtonTheme:
         _getFloatingActionButtonThemeData(colorScheme, Brightness.light),
     bottomNavigationBarTheme: BottomNavigationBarThemeData(
@@ -559,7 +545,7 @@ ThemeData createYaruDarkTheme({
     checkboxTheme: _getCheckBoxThemeData(colorScheme, Brightness.dark),
     radioTheme: _getRadioThemeData(colorScheme, Brightness.dark),
     primaryColorDark: primaryColor,
-    appBarTheme: _createDarkAppBarTheme(colorScheme),
+    appBarTheme: _createAppBarTheme(colorScheme, Brightness.dark),
     floatingActionButtonTheme:
         _getFloatingActionButtonThemeData(colorScheme, Brightness.dark),
     bottomNavigationBarTheme: BottomNavigationBarThemeData(


### PR DESCRIPTION
Should be the same except that `iconTheme` and `actionsIconTheme` were previously only specified for light app bars.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/224151715-e4eabcc4-714f-4733-b11f-ab9c073e4223.png) | ![image](https://user-images.githubusercontent.com/140617/224151434-9ca57034-f80f-40c2-af8b-1c3c6f499720.png) |
| ![image](https://user-images.githubusercontent.com/140617/224151690-1899501c-b585-45b1-aefe-7487ece7abfb.png) | ![image](https://user-images.githubusercontent.com/140617/224151345-2f9bcb66-900d-4c00-a664-00e36670d181.png) |