### PR TITLE
BottomNavigationBarTheme: use onSurface in dark theme

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -550,7 +550,7 @@ ThemeData createYaruDarkTheme({
         _getFloatingActionButtonThemeData(colorScheme, Brightness.dark),
     bottomNavigationBarTheme: BottomNavigationBarThemeData(
       selectedItemColor: colorScheme.primary,
-      unselectedItemColor: Colors.white.withOpacity(0.8),
+      unselectedItemColor: colorScheme.onSurface.withOpacity(0.8),
     ),
     inputDecorationTheme:
         _createInputDecorationTheme(colorScheme, Brightness.dark),


### PR DESCRIPTION
To unify with the light theme.

NOTE: `ColorScheme.onSurface` is not clean white but `#fafafa` aka "porcelain". Consequently, the resulting translucent color against the background changes from `#d5d5d5` to `#d1d1d1`.

| Before | After |
|---|---|
| ![Screenshot from 2023-03-09 22-35-55](https://user-images.githubusercontent.com/140617/224165890-20eb4847-a9ee-4382-90cd-f2cb9a97fe05.png) | ![Screenshot from 2023-03-09 22-36-19](https://user-images.githubusercontent.com/140617/224165907-47b3d7b8-80fa-43f7-b628-46e6d7e00e68.png) |
