### PR TITLE
indicatorColor: use primary for both light and dark themes

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -417,7 +417,7 @@ ThemeData createYaruLightTheme({
     dividerColor: kDividerColorLight,
     dialogBackgroundColor: colorScheme.background,
     textTheme: createTextTheme(YaruColors.inkstone),
-    indicatorColor: colorScheme.secondary,
+    indicatorColor: colorScheme.primary,
     applyElevationOverlayColor: false,
     buttonTheme: _buttonThemeData,
     outlinedButtonTheme: _createOutlinedButtonThemeData(colorScheme),


### PR DESCRIPTION
It's only used for M2 tabs in Flutter but make it consistent between the light and dark themes anyway so it'll be possible to share the theme creation without parameterizing indicatorColor.