### PR TITLE
Menus: use surface variant in dark theme, surface in light theme

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -475,7 +475,7 @@ ThemeData createYaruDarkTheme({
     inverseSurface: YaruColors.porcelain,
     onInverseSurface: YaruColors.inkstone,
     surfaceTint: YaruColors.coolGrey,
-    surfaceVariant: YaruColors.inkstone,
+    surfaceVariant: const Color.fromARGB(255, 34, 34, 34),
     tertiary: const Color(0xFF18b6ec),
     onTertiary: YaruColors.porcelain,
     tertiaryContainer: const Color(0xFF18b6ec),
@@ -502,8 +502,8 @@ Color contrastColor(Color color) => ThemeData.estimateBrightnessForColor(
 
 PopupMenuThemeData _createPopupMenuThemeData(ColorScheme colorScheme) {
   final bgColor = colorScheme.brightness == Brightness.dark
-      ? const Color.fromARGB(255, 34, 34, 34)
-      : Colors.white;
+      ? colorScheme.surfaceVariant
+      : colorScheme.surface;
   return PopupMenuThemeData(
     color: bgColor,
     surfaceTintColor: bgColor,
@@ -521,9 +521,8 @@ PopupMenuThemeData _createPopupMenuThemeData(ColorScheme colorScheme) {
 
 MenuStyle _createMenuStyle(ColorScheme colorScheme) {
   final bgColor = colorScheme.brightness == Brightness.dark
-      ? const Color.fromARGB(255, 34, 34, 34)
-      : Colors.white;
-
+      ? colorScheme.surfaceVariant
+      : colorScheme.surface;
   return MenuStyle(
     surfaceTintColor: MaterialStateColor.resolveWith((states) => bgColor),
     shape: MaterialStateProperty.resolveWith(


### PR DESCRIPTION
Moving the previously hardcoded `rgb(34,34,34)` color into the color scheme makes it possible to:
- configure the background color of menus for high-contrast and flavors themes, and
- use the appropriate background color in custom widgets such as `YaruAutocomplete`.

Popup menus look the same as before in both light and dark themes. The only effective change is that `surfaceVariant` has now a different value in the dark theme. I sincerely hope that `surfaceVariant` was a safe choice for this but it's hard to know where it might be used... :sweat_smile: 

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/224485704-55c458b3-80c3-40d2-8407-756ca8101988.png) | ![image](https://user-images.githubusercontent.com/140617/224485538-7d73b78e-1d6b-4de9-9f17-c3830ffb251a.png) |
| ![image](https://user-images.githubusercontent.com/140617/224485789-87a3bcf8-029b-4b36-9d36-4860e13f3966.png) | ![image](https://user-images.githubusercontent.com/140617/224485603-28cd07f9-54fc-45b6-8e5e-bd1d320231ce.png) |
| ![image](https://user-images.githubusercontent.com/140617/224485683-a90bd7ad-81c8-4f86-87a1-398dd4792569.png) | ![image](https://user-images.githubusercontent.com/140617/224485314-91a43866-8bb1-4624-8a64-2ddcf20b0fc4.png) |
| ![image](https://user-images.githubusercontent.com/140617/224485760-43715826-b4f2-45ce-9ffd-b4f9c4eaf9c4.png) | ![image](https://user-images.githubusercontent.com/140617/224485616-3c6d418d-f7ce-48fe-8a31-f205532be7b7.png) |

Ref: ubuntu/yaru_widgets.dart#845
Ref: ubuntu/yaru_widgets.dart#668