### PR TITLE
Switch: use onPrimary for selected thumb to match primary track

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -220,7 +220,7 @@ Color _getSwitchThumbColor(Set<MaterialState> states, ColorScheme colorScheme) {
     return colorScheme.onSurface.withOpacity(0.5);
   } else {
     if (states.contains(MaterialState.selected)) {
-      return Colors.white;
+      return colorScheme.onPrimary;
     } else {
       return colorScheme.onSurface.withOpacity(0.7);
     }


### PR DESCRIPTION
Fixes the thumb color in the selected mode, when using a dark high-contrast color scheme. In that scenario, the thumb needs to be black instead of white (the first pair of screenshots). Should make no difference for other themes.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/224489172-ce5be0a9-5fdc-4100-8861-42323b7b9b8c.png) | ![image](https://user-images.githubusercontent.com/140617/224489164-e964f70f-9cb9-4574-8f9d-9598d0c5f57e.png) |
| ![image](https://user-images.githubusercontent.com/140617/224489259-858e50f4-9e26-4477-90a0-086e31faf57c.png) | ![image](https://user-images.githubusercontent.com/140617/224489271-48afc095-b287-442b-a077-1168ae0b00ce.png) |
| ![image](https://user-images.githubusercontent.com/140617/224489192-d5af256f-5163-4e85-aa17-956a0be53caa.png) | ![image](https://user-images.githubusercontent.com/140617/224489198-196a3428-212e-4720-8404-5467bed43fef.png) |
| ![image](https://user-images.githubusercontent.com/140617/224489219-691f1358-13d2-4595-8079-0d19d7083ce7.png) | ![image](https://user-images.githubusercontent.com/140617/224489210-5d6c8ca2-7110-4efd-b1ba-b5b20e46f3f2.png) |
