### PR TITLE
Change FAB Color and shape

### DIFF
--- a/example/lib/view/controls_view.dart
+++ b/example/lib/view/controls_view.dart
@@ -184,19 +184,19 @@ class _ControlsViewState extends State<ControlsView>
                         runSpacing: 10,
                         children: [
                           FloatingActionButton(
-                            onPressed: () => {incrementCounter()},
+                            onPressed: incrementCounter,
                             child: const Icon(Icons.plus_one),
                           ),
                           FloatingActionButton.extended(
-                            onPressed: () => {incrementCounter()},
+                            onPressed: incrementCounter,
                             label: const Text('Yay! +1 ❤️ for Yaru'),
                           ),
                           FloatingActionButton.small(
-                            onPressed: () => {incrementCounter()},
+                            onPressed: incrementCounter,
                             child: const Icon(Icons.plus_one),
                           ),
                           FloatingActionButton.large(
-                            onPressed: () => {incrementCounter()},
+                            onPressed: incrementCounter,
                             child: const Icon(Icons.plus_one),
                           ),
                         ],

--- a/example/lib/view/controls_view.dart
+++ b/example/lib/view/controls_view.dart
@@ -179,9 +179,23 @@ class _ControlsViewState extends State<ControlsView>
                     ),
                     Padding(
                       padding: const EdgeInsets.all(8.0),
-                      child: Row(
+                      child: Wrap(
+                        spacing: 10,
+                        runSpacing: 10,
                         children: [
                           FloatingActionButton(
+                            onPressed: () => {incrementCounter()},
+                            child: const Icon(Icons.plus_one),
+                          ),
+                          FloatingActionButton.extended(
+                            onPressed: () => {incrementCounter()},
+                            label: const Text('Yay! +1 ❤️ for Yaru'),
+                          ),
+                          FloatingActionButton.small(
+                            onPressed: () => {incrementCounter()},
+                            child: const Icon(Icons.plus_one),
+                          ),
+                          FloatingActionButton.large(
                             onPressed: () => {incrementCounter()},
                             child: const Icon(Icons.plus_one),
                           ),

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -329,15 +329,17 @@ ProgressIndicatorThemeData _createProgressIndicatorTheme(
 }
 
 FloatingActionButtonThemeData _getFloatingActionButtonThemeData(
-  ColorScheme colorScheme,
-) {
+  ColorScheme colorScheme, [
+  Color? buttonColor,
+]) {
   const elevation = 3.0;
+  final bg = buttonColor ?? colorScheme.primary;
 
   return FloatingActionButtonThemeData(
-    backgroundColor: colorScheme.surface
-        .scale(lightness: colorScheme.isLight ? -0.10 : 0.20),
-    foregroundColor: colorScheme.onSurface,
-    shape: CircleBorder(
+    backgroundColor: bg,
+    foregroundColor: contrastColor(bg),
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(30),
       side: colorScheme.isHighContrast
           ? BorderSide(color: colorScheme.outlineVariant)
           : BorderSide.none,
@@ -404,7 +406,8 @@ ThemeData createYaruTheme({
     radioTheme: _getRadioThemeData(colorScheme),
     primaryColorDark: colorScheme.isDark ? colorScheme.primary : null,
     appBarTheme: _createAppBarTheme(colorScheme),
-    floatingActionButtonTheme: _getFloatingActionButtonThemeData(colorScheme),
+    floatingActionButtonTheme:
+        _getFloatingActionButtonThemeData(colorScheme, elevatedButtonColor),
     bottomNavigationBarTheme: BottomNavigationBarThemeData(
       selectedItemColor: colorScheme.primary,
       unselectedItemColor: colorScheme.onSurface.withOpacity(0.8),


### PR DESCRIPTION
- Use RoundedRectangularBorder with a big border radius to avoid clipping of text
- Revert the default colors back to elevatedcolor if provided or primary color if not
- updated the example to show the different button types

![grafik](https://user-images.githubusercontent.com/15329494/225282415-979527ea-f627-47f5-957a-472e08d7d50d.png)
![grafik](https://user-images.githubusercontent.com/15329494/225282493-415fc921-3014-4b91-a483-92f593ad8669.png)
![grafik](https://user-images.githubusercontent.com/15329494/225283039-4b1a705b-2ce6-4aee-9fd8-bf01a88f0a9b.png)
![grafik](https://user-images.githubusercontent.com/15329494/225283063-5c2fda59-2b18-40df-a9b4-a72b7754d07e.png)



Fixes #294
Fixes #282