### PR TITLE
export colorscheme extension for convenience

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -627,7 +627,7 @@ NavigationRailThemeData _createNavigationRailTheme(ColorScheme colorScheme) {
   );
 }
 
-extension on ColorScheme {
+extension YaruColorSchemeX on ColorScheme {
   bool get isDark => brightness == Brightness.dark;
   bool get isLight => brightness == Brightness.light;
   bool get isHighContrast => [Colors.black, Colors.white].contains(primary);


### PR DESCRIPTION
allows us to use `isHighContrast` etc in places like yaru_widgets