### PR TITLE
ci: pin flutter version at 3.10.x

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -17,6 +17,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
+        flutter-version: '3.10.x'
 
     - name: Get dependencies
       run: flutter pub get
@@ -32,6 +33,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
+        flutter-version: '3.10.x'
 
     - name: Get dependencies
       run: flutter pub get
@@ -51,6 +53,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
+        flutter-version: '3.10.x'
 
     - name: Check for any formatting issues
       run: dart format --set-exit-if-changed .
@@ -63,6 +66,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
+        flutter-version: '3.10.x'
 
     - name: Get dependencies
       run: flutter pub get
@@ -78,6 +82,7 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'
+        flutter-version: '3.10.x'
 
     - name: Get dependencies
       run: flutter pub get

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
+        with:
+          channel: 'stable'
+          flutter-version: '3.10.x'
       - uses: bluefireteam/flutter-gh-pages@v7
         with:
           workingDir: example


### PR DESCRIPTION
Follow the latest patch release in 3.10.x series but prevent minor or major releases from breaking the CI.