### PR TITLE
feat: Adapt SwitchTheme to yaru gnome

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -224,6 +224,9 @@ DialogTheme _createDialogTheme(ColorScheme colorScheme) {
 
 SwitchThemeData _createSwitchTheme(ColorScheme colorScheme) {
   return SwitchThemeData(
+    trackOutlineColor: MaterialStateColor.resolveWith(
+      (states) => Colors.transparent,
+    ),
     thumbColor: MaterialStateProperty.resolveWith(
       (states) => _getSwitchThumbColor(states, colorScheme),
     ),
@@ -240,22 +243,25 @@ Color _getSwitchThumbColor(Set<MaterialState> states, ColorScheme colorScheme) {
     }
     return colorScheme.onSurface.withOpacity(0.5);
   } else {
-    if (states.contains(MaterialState.selected)) {
-      return colorScheme.onPrimary;
-    } else {
-      return colorScheme.onSurface.withOpacity(0.7);
-    }
+    return colorScheme.onPrimary;
   }
 }
 
 Color _getSwitchTrackColor(Set<MaterialState> states, ColorScheme colorScheme) {
+  final uncheckedColor = colorScheme.onSurface.withOpacity(.25);
+  final disabledUncheckedColor = colorScheme.onSurface.withOpacity(.15);
+  final disabledCheckedColor = colorScheme.onSurface.withOpacity(.18);
+
   if (states.contains(MaterialState.disabled)) {
-    return colorScheme.onSurface.withOpacity(0.15);
+    if (states.contains(MaterialState.selected)) {
+      return disabledCheckedColor;
+    }
+    return disabledUncheckedColor;
   } else {
     if (states.contains(MaterialState.selected)) {
       return colorScheme.primary;
     } else {
-      return colorScheme.outline;
+      return uncheckedColor;
     }
   }
 }


### PR DESCRIPTION
- transparent border
- darker grey for inactive switches, based on the colorScheme to stay themeable

This is possible now since flutter 3.10

<img width="192" alt="grafik" src="https://github.com/ubuntu/yaru.dart/assets/15329494/4af8551b-630c-4341-ad01-85ad44fdf0f7">
vs yaru widgets
<img width="192" alt="grafik" src="https://github.com/ubuntu/yaru.dart/assets/15329494/442ec46c-d9d2-4a37-8bb2-9d6e029f2fd9">

previously:
<img width="192" alt="grafik" src="https://github.com/ubuntu/yaru.dart/assets/15329494/158a805f-7399-4f88-ae07-3b17fe8abf37">
