### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# 0.8.0
+
+* feat: Adapt SwitchTheme to yaru gnome by @Feichtmeier (#345) 
+* ci: pin flutter version at 3.10.x by @jpnurmi (#344) 
+* Import YaruColorExtension from yaru_colors.dart by @jpnurmi (#341)
+* Migrate to Flutter 3.10 & Dart 3.0 by @jpnurmi (#342) 
+* Add a DrawerTheme and ListTileTheme by @Feichtmeier (#340)
+
 # 0.7.0
 
 * Transfer colors (back) to yaru.dart by @Feichtmeier (#333)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaru
-version: 0.7.0
+version: 0.8.0
 
 description: Ubuntu Yaru Style - Distinct look and feel of the Ubuntu Desktop
 


### PR DESCRIPTION
Raising the major version since this release requires a min dart 3.0 and flutter 3.10
For the next one we could try your auto thing @jpnurmi 
Just wanted to get this one into pub so we can also upgrade yaru widgets


# 0.8.0

* feat: Adapt SwitchTheme to yaru gnome by @Feichtmeier (#345) 
* ci: pin flutter version at 3.10.x by @jpnurmi (#344) 
* Import YaruColorExtension from yaru_colors.dart by @jpnurmi (#341)
* Migrate to Flutter 3.10 & Dart 3.0 by @jpnurmi (#342) 
* Add a DrawerTheme and ListTileTheme by @Feichtmeier (#340)
