### PR TITLE
feat: add YaruColorSchemeExtension.link and .inverseLink

### DIFF
--- a/example/lib/view/colors_view.dart
+++ b/example/lib/view/colors_view.dart
@@ -208,6 +208,7 @@ class ColorsView extends StatelessWidget {
           children: [
             _colorContainer('success', theme.colorScheme.success),
             _colorContainer('warning', theme.colorScheme.warning),
+            _colorContainer('link', theme.colorScheme.link),
           ],
         ),
       ],

--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -55,6 +55,12 @@ class YaruColors {
   /// Dark title bar
   static const Color titleBarDark = Color(0xFF303030);
 
+  /// Light link
+  static const Color linkLight = Color(0xFF0094FF); // YaruColors.blue[500]
+
+  /// Dark link
+  static const Color linkDark = Color(0xFF0073E5); // YaruColors.blue[700]
+
   /// Olive
   static const Color olive = Color(0xFF4B8501);
 

--- a/lib/src/themes/extensions.dart
+++ b/lib/src/themes/extensions.dart
@@ -43,4 +43,22 @@ extension YaruColorSchemeExtension on ColorScheme {
   /// See also:
   ///  * [ColorScheme.error]
   Color get warning => YaruColors.warning;
+
+  /// A color for presenting links.
+  ///
+  /// ```dart
+  /// Theme.of(context).colorScheme.link
+  /// ```
+  Color get link => brightness == Brightness.light
+      ? YaruColors.linkDark
+      : YaruColors.linkLight;
+
+  /// A color for presenting links on [inverseSurface].
+  ///
+  /// ```dart
+  /// Theme.of(context).colorScheme.inverseLink
+  /// ```
+  Color get inverseLink => brightness == Brightness.light
+      ? YaruColors.linkLight
+      : YaruColors.linkDark;
 }


### PR DESCRIPTION
The same `YaruColors.blue` (`#0073E5`) shade is not optimal for both light and dark themes. This PR introduces a convenience getter that uses the former `YaruColors.blue[700]` (`#0073E5`) and `YaruColors.blue[500]` (`#0094FF`) shades in the light and dark themes, respectively, to ensure better contrast.

| Light | Dark |
|---|---|
| ![image](https://github.com/ubuntu/yaru.dart/assets/140617/16e449fc-0037-4e50-a9e0-caac5466ac31) | ![image](https://github.com/ubuntu/yaru.dart/assets/140617/4ea8c1c2-299e-49ec-9999-d9f87d97bf47) |

The same link colors are currently being used in the installer and the software store. The `yaru_colors` package with multi-shade colors is going away so this is an attempt to provide a replacement.

- Dark link color in light theme: `#0073E5`
- Light link color in dark theme: `#0094FF`

See also:
- https://github.com/canonical/ubuntu-desktop-installer/pull/1486
- https://github.com/ubuntu-flutter-community/software/pull/1150
