### PR TITLE
feat: deprecate YaruThemeDataExtension in favor of YaruColorSchemeExtension

### DIFF
--- a/example/lib/view/colors_view.dart
+++ b/example/lib/view/colors_view.dart
@@ -193,6 +193,23 @@ class ColorsView extends StatelessWidget {
             _colorContainer('xubuntuBlue', YaruColors.xubuntuBlue),
           ],
         ),
+        const _SpacedDivider(),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 20, left: 5),
+          child: Text(
+            'Extension Colors',
+            style: headlineStyle,
+          ),
+        ),
+        GridView(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          gridDelegate: _gridDelegate,
+          children: [
+            _colorContainer('success', theme.colorScheme.success),
+            _colorContainer('warning', theme.colorScheme.warning),
+          ],
+        ),
       ],
     );
   }

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:yaru/src/colors.dart';
 import 'package:yaru/src/text/text_theme.dart';
 import 'package:yaru/src/themes/constants.dart';
+import 'package:yaru/src/themes/extensions.dart';
 import 'package:yaru/src/themes/page_transitions.dart';
 
 const kDividerColorDark = Color.fromARGB(255, 65, 65, 65);
@@ -483,12 +484,6 @@ DrawerThemeData _createDrawerTheme(ColorScheme colorScheme) {
     ),
     backgroundColor: colorScheme.background,
   );
-}
-
-extension YaruColorSchemeX on ColorScheme {
-  bool get isDark => brightness == Brightness.dark;
-  bool get isLight => brightness == Brightness.light;
-  bool get isHighContrast => [Colors.black, Colors.white].contains(primary);
 }
 
 /// Helper function to create a new Yaru theme

--- a/lib/src/themes/extensions.dart
+++ b/lib/src/themes/extensions.dart
@@ -19,7 +19,8 @@ extension YaruColorSchemeExtension on ColorScheme {
   bool get isLight => brightness == Brightness.light;
 
   /// Whether the primary color is either black or white.
-  bool get isHighContrast => [Colors.black, Colors.white].contains(primary);
+  bool get isHighContrast =>
+      const [Colors.black, Colors.white].contains(primary);
 
   /// A color to indicate success e.g. for text input validation.
   ///

--- a/lib/src/themes/extensions.dart
+++ b/lib/src/themes/extensions.dart
@@ -4,10 +4,10 @@ import 'package:yaru/src/colors.dart';
 @Deprecated('Use YaruColorSchemeExtension instead.')
 extension YaruThemeDataExtension on ThemeData {
   @Deprecated('Use ColorScheme.success instead.')
-  Color get successColor => YaruColors.success;
+  Color get successColor => colorScheme.success;
 
   @Deprecated('Use ColorScheme.warning instead.')
-  Color get warningColor => YaruColors.warning;
+  Color get warningColor => colorScheme.warning;
 }
 
 /// Yaru-specific color scheme extensions.

--- a/lib/src/themes/extensions.dart
+++ b/lib/src/themes/extensions.dart
@@ -12,6 +12,15 @@ extension YaruThemeDataExtension on ThemeData {
 
 /// Yaru-specific color scheme extensions.
 extension YaruColorSchemeExtension on ColorScheme {
+  /// Whether the brightness is dark.
+  bool get isDark => brightness == Brightness.dark;
+
+  /// Whether the brightness is light.
+  bool get isLight => brightness == Brightness.light;
+
+  /// Whether the primary color is either black or white.
+  bool get isHighContrast => [Colors.black, Colors.white].contains(primary);
+
   /// A color to indicate success e.g. for text input validation.
   ///
   /// ```dart

--- a/lib/src/themes/extensions.dart
+++ b/lib/src/themes/extensions.dart
@@ -1,27 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:yaru/src/colors.dart';
 
-/// Yaru-specific theming extensions.
+@Deprecated('Use YaruColorSchemeExtension instead.')
 extension YaruThemeDataExtension on ThemeData {
+  @Deprecated('Use ColorScheme.success instead.')
+  Color get successColor => YaruColors.success;
+
+  @Deprecated('Use ColorScheme.warning instead.')
+  Color get warningColor => YaruColors.warning;
+}
+
+/// Yaru-specific color scheme extensions.
+extension YaruColorSchemeExtension on ColorScheme {
   /// A color to indicate success e.g. for text input validation.
   ///
   /// ```dart
-  /// Theme.of(context).successColor
+  /// Theme.of(context).colorScheme.success
   /// ```
   ///
   /// See also:
-  ///  * [ThemeData.colorScheme.error]
-  Color get successColor => YaruColors.success;
+  ///  * [ColorScheme.error]
+  Color get success => YaruColors.success;
 
   /// A color to indicate warnings.
   ///
-  /// This is the counterpart of [ThemeData.colorScheme.error].
+  /// This is the counterpart of [ColorScheme.error].
   ///
   /// ```dart
-  /// Theme.of(context).warningColor
+  /// Theme.of(context).colorScheme.warning
   /// ```
   ///
   /// See also:
-  ///  * [ThemeData.colorScheme.error]
-  Color get warningColor => YaruColors.warning;
+  ///  * [ColorScheme.error]
+  Color get warning => YaruColors.warning;
 }


### PR DESCRIPTION
YaruThemeDataExtension.successColor and friends were introduced before Flutter started moving color properties from ThemeData into a separate ColorScheme object. This PR adapts to that and paves the road for introducing more custom color extensions (e.g. link color in #348).