### PR TITLE
feat: theme-specific error colors

### DIFF
--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -31,8 +31,14 @@ class YaruColors {
   /// only.
   static const Color textGrey = Color(0xFF111111);
 
-  /// Error
+  @Deprecated('Use errorLight or errorDark instead.')
   static const Color error = Color(0xFFff0000);
+
+  /// Light error
+  static const Color errorLight = Color(0xFFE86581); // YaruColors.red[300]
+
+  /// Dark error
+  static const Color errorDark = Color(0xFFB52A4A); // YaruColors.red[700]
 
   /// Warning
   static const Color warning = Color(0xFFf99b11);

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -582,7 +582,8 @@ ThemeData createYaruLightTheme({
 }) {
   final colorScheme = ColorScheme.fromSeed(
     seedColor: primaryColor,
-    error: YaruColors.error,
+    error: YaruColors.errorDark,
+    onError: Colors.white,
     brightness: Brightness.light,
     primary: primaryColor,
     onPrimary: contrastColor(primaryColor),
@@ -630,7 +631,8 @@ ThemeData createYaruDarkTheme({
 }) {
   final colorScheme = ColorScheme.fromSeed(
     seedColor: primaryColor,
-    error: YaruColors.error,
+    error: YaruColors.errorLight,
+    onError: Colors.white,
     brightness: Brightness.dark,
     primary: primaryColor,
     primaryContainer: YaruColors.coolGrey,


### PR DESCRIPTION
Use theme-specific error shades because `#ff0000` text doesn't work well against a dark background.

| Before | After |
|---|---|
| ![image](https://github.com/ubuntu/yaru.dart/assets/140617/608545ed-08f6-4f2a-b7cd-8bcbe5ae8c12) | ![Screenshot from 2023-05-30 17-05-08](https://github.com/ubuntu/yaru.dart/assets/140617/9328af6d-8bf9-4f9d-9295-49e5251fef75) |
| ![image](https://github.com/ubuntu/yaru.dart/assets/140617/17ee7549-edee-4344-8717-d911346df760) | ![Screenshot from 2023-05-30 17-05-00](https://github.com/ubuntu/yaru.dart/assets/140617/c51179bf-781b-4e76-8f75-8cfc5aae1087) |

The colors were taken from, originally proposed by @elioqoshi:
- https://github.com/canonical/ubuntu-desktop-installer/pull/1655

Close: #214