### PR TITLE
feat(colors)!: introduce theme-specific semantic colors

### DIFF
--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -31,19 +31,19 @@ class YaruColors {
   /// only.
   static const Color textGrey = Color(0xFF111111);
 
-  @Deprecated('Use errorLight or errorDark instead.')
+  @Deprecated('Use YaruColorScheme.error instead.')
   static const Color error = Color(0xFFff0000);
 
-  /// Light error
+  @Deprecated('Use YaruColorScheme.error instead.')
   static const Color errorLight = Color(0xFFE86581); // YaruColors.red[300]
 
-  /// Dark error
+  @Deprecated('Use YaruColorScheme.error instead.')
   static const Color errorDark = Color(0xFFB52A4A); // YaruColors.red[700]
 
-  /// Warning
+  @Deprecated('Use YaruColorScheme.warning instead.')
   static const Color warning = Color(0xFFf99b11);
 
-  /// Success
+  @Deprecated('Use YaruColorScheme.success instead.')
   static const Color success = Color(0xFF0e8420);
 
   /// Porcelain
@@ -61,10 +61,10 @@ class YaruColors {
   /// Dark title bar
   static const Color titleBarDark = Color(0xFF303030);
 
-  /// Light link
+  @Deprecated('Use YaruColorScheme.link instead.')
   static const Color linkLight = Color(0xFF0094FF); // YaruColors.blue[500]
 
-  /// Dark link
+  @Deprecated('Use YaruColorScheme.link instead.')
   static const Color linkDark = Color(0xFF0073E5); // YaruColors.blue[700]
 
   /// Olive
@@ -120,6 +120,58 @@ class YaruColors {
 
   /// Xubuntu Blue
   static const Color xubuntuBlue = Color(0xFF0044AA);
+}
+
+/// Yaru color scheme.
+class YaruColorScheme {
+  /// Creates a color scheme with the given colors.
+  const YaruColorScheme({
+    required this.error,
+    required this.success,
+    required this.warning,
+    required this.link,
+  });
+
+  /// Error color
+  final Color error;
+
+  /// Success color
+  final Color success;
+
+  /// Warning color
+  final Color warning;
+
+  /// Link color
+  final Color link;
+
+  /// Color scheme for a light theme.
+  static const light = YaruColorScheme(
+    error: Color(0xFFB52A4A), // YaruColors.red[700],
+    success: Color(0xFF0e8420),
+    warning: Color(0xFFf99b11),
+    link: Color(0xFF0073E5), // YaruColors.blue[700],
+  );
+
+  /// Color scheme for a dark theme.
+  static const dark = YaruColorScheme(
+    error: Color(0xFFE86581), // YaruColors.red[300]
+    success: Color(0xFF0e8420),
+    warning: Color(0xFFf99b11),
+    link: Color(0xFF0094FF), // YaruColors.blue[500]
+  );
+
+  /// Color scheme from the given [brightness].
+  factory YaruColorScheme.from(Brightness brightness) {
+    return switch (brightness) {
+      Brightness.light => YaruColorScheme.light,
+      Brightness.dark => YaruColorScheme.dark,
+    };
+  }
+
+  /// Color scheme for the given [context].
+  static YaruColorScheme of(BuildContext context) {
+    return YaruColorScheme.from(Theme.of(context).brightness);
+  }
 }
 
 /// Set of useful methods when working with [Color]

--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -2,7 +2,41 @@ import 'package:flutter/material.dart';
 
 /// Available Yaru colors.
 class YaruColors {
-  YaruColors._();
+  const YaruColors._({
+    required this.error,
+    required this.success,
+    required this.warning,
+    required this.link,
+  });
+
+  /// Colors derived from the given [brightness].
+  factory YaruColors.from(Brightness brightness) {
+    return switch (brightness) {
+      Brightness.light => YaruColors.light,
+      Brightness.dark => YaruColors.dark,
+    };
+  }
+
+  /// Colors for the given [context].
+  static YaruColors of(BuildContext context) {
+    return YaruColors.from(Theme.of(context).brightness);
+  }
+
+  /// Theme-specific colors for light themes.
+  static const light = YaruColors._(
+    error: Color(0xFFB52A4A), // YaruColors.red[700],
+    success: Color(0xFF0e8420),
+    warning: Color(0xFFf99b11),
+    link: Color(0xFF0073E5), // YaruColors.blue[700],
+  );
+
+  /// Theme-specific colors for dark themes.
+  static const dark = YaruColors._(
+    error: Color(0xFFE86581), // YaruColors.red[300]
+    success: Color(0xFF0e8420),
+    warning: Color(0xFFf99b11),
+    link: Color(0xFF0094FF), // YaruColors.blue[500]
+  );
 
   /// Ubuntu Orange
   static const Color orange = Color(0xFFE95420);
@@ -31,20 +65,20 @@ class YaruColors {
   /// only.
   static const Color textGrey = Color(0xFF111111);
 
-  @Deprecated('Use YaruColorScheme.error instead.')
-  static const Color error = Color(0xFFff0000);
+  /// Error
+  final Color error;
 
-  @Deprecated('Use YaruColorScheme.error instead.')
+  @Deprecated('Use YaruColors.dark.error instead.')
   static const Color errorLight = Color(0xFFE86581); // YaruColors.red[300]
 
-  @Deprecated('Use YaruColorScheme.error instead.')
+  @Deprecated('Use YaruColors.light.error instead.')
   static const Color errorDark = Color(0xFFB52A4A); // YaruColors.red[700]
 
-  @Deprecated('Use YaruColorScheme.warning instead.')
-  static const Color warning = Color(0xFFf99b11);
+  /// Warning
+  final Color warning;
 
-  @Deprecated('Use YaruColorScheme.success instead.')
-  static const Color success = Color(0xFF0e8420);
+  /// Success
+  final Color success;
 
   /// Porcelain
   static const Color porcelain = Color(0xFFFAFAFA);
@@ -61,10 +95,13 @@ class YaruColors {
   /// Dark title bar
   static const Color titleBarDark = Color(0xFF303030);
 
-  @Deprecated('Use YaruColorScheme.link instead.')
+  /// Link
+  final Color link;
+
+  @Deprecated('Use YaruColors.dark.link instead.')
   static const Color linkLight = Color(0xFF0094FF); // YaruColors.blue[500]
 
-  @Deprecated('Use YaruColorScheme.link instead.')
+  @Deprecated('Use YaruColors.light.link instead.')
   static const Color linkDark = Color(0xFF0073E5); // YaruColors.blue[700]
 
   /// Olive
@@ -120,58 +157,6 @@ class YaruColors {
 
   /// Xubuntu Blue
   static const Color xubuntuBlue = Color(0xFF0044AA);
-}
-
-/// Yaru color scheme.
-class YaruColorScheme {
-  /// Creates a color scheme with the given colors.
-  const YaruColorScheme({
-    required this.error,
-    required this.success,
-    required this.warning,
-    required this.link,
-  });
-
-  /// Error color
-  final Color error;
-
-  /// Success color
-  final Color success;
-
-  /// Warning color
-  final Color warning;
-
-  /// Link color
-  final Color link;
-
-  /// Color scheme for a light theme.
-  static const light = YaruColorScheme(
-    error: Color(0xFFB52A4A), // YaruColors.red[700],
-    success: Color(0xFF0e8420),
-    warning: Color(0xFFf99b11),
-    link: Color(0xFF0073E5), // YaruColors.blue[700],
-  );
-
-  /// Color scheme for a dark theme.
-  static const dark = YaruColorScheme(
-    error: Color(0xFFE86581), // YaruColors.red[300]
-    success: Color(0xFF0e8420),
-    warning: Color(0xFFf99b11),
-    link: Color(0xFF0094FF), // YaruColors.blue[500]
-  );
-
-  /// Color scheme from the given [brightness].
-  factory YaruColorScheme.from(Brightness brightness) {
-    return switch (brightness) {
-      Brightness.light => YaruColorScheme.light,
-      Brightness.dark => YaruColorScheme.dark,
-    };
-  }
-
-  /// Color scheme for the given [context].
-  static YaruColorScheme of(BuildContext context) {
-    return YaruColorScheme.from(Theme.of(context).brightness);
-  }
 }
 
 /// Set of useful methods when working with [Color]

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -582,7 +582,7 @@ ThemeData createYaruLightTheme({
 }) {
   final colorScheme = ColorScheme.fromSeed(
     seedColor: primaryColor,
-    error: YaruColors.errorDark,
+    error: YaruColorScheme.light.error,
     onError: Colors.white,
     brightness: Brightness.light,
     primary: primaryColor,
@@ -631,7 +631,7 @@ ThemeData createYaruDarkTheme({
 }) {
   final colorScheme = ColorScheme.fromSeed(
     seedColor: primaryColor,
-    error: YaruColors.errorLight,
+    error: YaruColorScheme.dark.error,
     onError: Colors.white,
     brightness: Brightness.dark,
     primary: primaryColor,

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -582,7 +582,7 @@ ThemeData createYaruLightTheme({
 }) {
   final colorScheme = ColorScheme.fromSeed(
     seedColor: primaryColor,
-    error: YaruColorScheme.light.error,
+    error: YaruColors.light.error,
     onError: Colors.white,
     brightness: Brightness.light,
     primary: primaryColor,
@@ -631,7 +631,7 @@ ThemeData createYaruDarkTheme({
 }) {
   final colorScheme = ColorScheme.fromSeed(
     seedColor: primaryColor,
-    error: YaruColorScheme.dark.error,
+    error: YaruColors.dark.error,
     onError: Colors.white,
     brightness: Brightness.dark,
     primary: primaryColor,

--- a/lib/src/themes/extensions.dart
+++ b/lib/src/themes/extensions.dart
@@ -30,7 +30,7 @@ extension YaruColorSchemeExtension on ColorScheme {
   ///
   /// See also:
   ///  * [ColorScheme.error]
-  Color get success => YaruColors.success;
+  Color get success => YaruColorScheme.from(brightness).success;
 
   /// A color to indicate warnings.
   ///
@@ -42,23 +42,24 @@ extension YaruColorSchemeExtension on ColorScheme {
   ///
   /// See also:
   ///  * [ColorScheme.error]
-  Color get warning => YaruColors.warning;
+  Color get warning => YaruColorScheme.from(brightness).warning;
 
   /// A color for presenting links.
   ///
   /// ```dart
   /// Theme.of(context).colorScheme.link
   /// ```
-  Color get link => brightness == Brightness.light
-      ? YaruColors.linkDark
-      : YaruColors.linkLight;
+  Color get link => YaruColorScheme.from(brightness).link;
 
   /// A color for presenting links on [inverseSurface].
   ///
   /// ```dart
   /// Theme.of(context).colorScheme.inverseLink
   /// ```
-  Color get inverseLink => brightness == Brightness.light
-      ? YaruColors.linkLight
-      : YaruColors.linkDark;
+  Color get inverseLink => YaruColorScheme.from(brightness.inverse).link;
+}
+
+extension on Brightness {
+  Brightness get inverse =>
+      this == Brightness.light ? Brightness.dark : Brightness.light;
 }

--- a/lib/src/themes/extensions.dart
+++ b/lib/src/themes/extensions.dart
@@ -30,7 +30,7 @@ extension YaruColorSchemeExtension on ColorScheme {
   ///
   /// See also:
   ///  * [ColorScheme.error]
-  Color get success => YaruColorScheme.from(brightness).success;
+  Color get success => YaruColors.from(brightness).success;
 
   /// A color to indicate warnings.
   ///
@@ -42,21 +42,21 @@ extension YaruColorSchemeExtension on ColorScheme {
   ///
   /// See also:
   ///  * [ColorScheme.error]
-  Color get warning => YaruColorScheme.from(brightness).warning;
+  Color get warning => YaruColors.from(brightness).warning;
 
   /// A color for presenting links.
   ///
   /// ```dart
   /// Theme.of(context).colorScheme.link
   /// ```
-  Color get link => YaruColorScheme.from(brightness).link;
+  Color get link => YaruColors.from(brightness).link;
 
   /// A color for presenting links on [inverseSurface].
   ///
   /// ```dart
   /// Theme.of(context).colorScheme.inverseLink
   /// ```
-  Color get inverseLink => YaruColorScheme.from(brightness.inverse).link;
+  Color get inverseLink => YaruColors.from(brightness.inverse).link;
 }
 
 extension on Brightness {

--- a/lib/src/themes/yaru.dart
+++ b/lib/src/themes/yaru.dart
@@ -5,12 +5,12 @@ const _primaryColor = YaruColors.orange;
 
 final yaruLight = createYaruLightTheme(
   primaryColor: _primaryColor,
-  elevatedButtonColor: YaruColors.success,
+  elevatedButtonColor: YaruColorScheme.light.success,
 );
 
 final yaruDark = createYaruDarkTheme(
   primaryColor: _primaryColor,
-  elevatedButtonColor: YaruColors.success,
+  elevatedButtonColor: YaruColorScheme.dark.success,
 );
 
 final yaruSageLight = createYaruLightTheme(

--- a/lib/src/themes/yaru.dart
+++ b/lib/src/themes/yaru.dart
@@ -5,12 +5,12 @@ const _primaryColor = YaruColors.orange;
 
 final yaruLight = createYaruLightTheme(
   primaryColor: _primaryColor,
-  elevatedButtonColor: YaruColorScheme.light.success,
+  elevatedButtonColor: YaruColors.light.success,
 );
 
 final yaruDark = createYaruDarkTheme(
   primaryColor: _primaryColor,
-  elevatedButtonColor: YaruColorScheme.dark.success,
+  elevatedButtonColor: YaruColors.dark.success,
 );
 
 final yaruSageLight = createYaruLightTheme(


### PR DESCRIPTION
No visual changes, only API changes.

The end-goal is to introduce different semantic "success", "warning" etc. color shades for light and dark themes because constant colors don't work well for both themes. This work was already started by introducing different error and link color shades:
- https://github.com/ubuntu/yaru.dart/pull/350
- https://github.com/ubuntu/yaru.dart/pull/348

Instead of introducing more `YaruColors.fooLight` and `fooDark` color constants in the future, this PR groups relevant colors into non-static members that can be specified separately for dark and light themes.

Before:
```dart
final fooColor = Theme.of(context).brightness == Brightness.light
    ? YaruColors.fooLight
    : YaruColors.fooDark;
```

After (of theme brightness):
```dart
final fooColor = YaruColors.of(context).foo;
```

Or (from the given brightness):
```dart
final barColor = YaruColors.from(Brightness.dark).bar;
```