### PR TITLE
feat: add YaruColorExtension.toHex() for passing colors to HTML

### DIFF
--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -256,4 +256,13 @@ extension YaruColorExtension on Color {
     return hslColor
         .withSaturation(hslColor.lightness == 0.0 ? 0.0 : hslColor.saturation);
   }
+
+  /// Returns a hex representation (`#AARRGGBB`) of the color.
+  String toHex() {
+    return '#${alpha.toHex()}${red.toHex()}${green.toHex()}${blue.toHex()}';
+  }
+}
+
+extension on int {
+  String toHex() => toRadixString(16).padLeft(2, '0');
 }

--- a/test/yaru_color_extension_test.dart
+++ b/test/yaru_color_extension_test.dart
@@ -198,4 +198,8 @@ void main() {
       );
     });
   });
+
+  test('hex', () {
+    expect(const Color(0x12345678).toHex(), '#12345678');
+  });
 }


### PR DESCRIPTION
Hex color formatting is not really Yaru's responsibility but would it fit here regardless, alongside the other color extensions?

For example:
```dart
Html(
  data: l10n.onBatteryWarning(Theme.of(context).colorScheme.warning.toHex()),
),
```
Where the translated string would contain a placeholder for the theme-dependent color, such as:
```json
"onBatteryWarning": "<font color=\"{color}\">Warning:</font> The computer is not plugged in to a power source.",
```