### PR TITLE
ci(release): temp override release-as 0.9.0

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -87,6 +87,7 @@ jobs:
           release-type: dart
           changelog-notes-type: github
           pull-request-title-pattern: 'chore: release v${version}'
+          release-as: 0.9.0
 
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The Dart ecosystem follows a special convention for 0.x versions such as that a breaking change in 0.8 results in 0.9, not 1.0. Help the release-please bot to version the next release accordingly. The parameter shall be removed after releasing 0.9.0.

> Although semantic versioning doesn’t promise any compatibility between versions prior to 1.0.0, the Dart community convention is to treat those versions semantically as well. The interpretation of each number is just shifted down one slot: going from 0.1.2 to 0.2.0 indicates a breaking change, going to 0.1.3 indicates a new feature, and going to 0.1.2+1 indicates a change that doesn’t affect the public API. For simplicity’s sake, avoid using + after the version reaches 1.0.0.

https://dart.dev/tools/pub/versioning#semantic-versions