### PR TITLE
feat: add static YaruVariant.accents

### DIFF
--- a/lib/src/themes/variant.dart
+++ b/lib/src/themes/variant.dart
@@ -61,6 +61,20 @@ enum YaruVariant {
 
   /// A dark theme for the variant.
   ThemeData get darkTheme => _yaruDarkThemes[this]!;
+
+  /// The available accent color variants excluding Ubuntu flavors.
+  static const List<YaruVariant> accents = [
+    orange,
+    bark,
+    sage,
+    olive,
+    viridian,
+    prussianGreen,
+    blue,
+    purple,
+    magenta,
+    red,
+  ];
 }
 
 final _yaruLightThemes = <YaruVariant, ThemeData>{


### PR DESCRIPTION
`YaruVariant.accents` makes it easy to implement an accent color selector by including only the Ubuntu accent colors. It excludes any variants for Ubuntu flavors that are included in `YaruVariant.values`.

Before:
```dart
for (final variant in YaruVariant.values.take(10)) // <===
  YaruColorDisk(
    color: variant.color,
    ...
  ),
```

After:
```dart
for (final variant in YaruVariant.accents)
  YaruColorDisk(
    color: variant.color,
    ...
  ),
```