### PR TITLE
ci: exempt github-actions[bot] from the CLA check

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -7,3 +7,5 @@ jobs:
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1
+        with:
+          exempted-bots: github-actions


### PR DESCRIPTION
Hopefully helps with the failing CLA check:
- https://github.com/ubuntu/yaru.dart/pull/357