### PR TITLE
fix!: set buttons and textfields to be 35px high

### DIFF
--- a/example/lib/view/controls_view.dart
+++ b/example/lib/view/controls_view.dart
@@ -163,30 +163,50 @@ class _ControlsViewState extends State<ControlsView>
                     ),
                     Padding(
                       padding: const EdgeInsets.all(8.0),
-                      child: SizedBox(
-                        height: 40,
-                        child: Row(
-                          children: [
-                            ToggleButtons(
-                              isSelected: _toggleButtons,
-                              onPressed: (v) =>
-                                  updateBoolList(_toggleButtons, v),
-                              children: [
-                                for (final v in _toggleButtons)
-                                  Text(v ? 'On' : 'Off'),
-                              ],
+                      child: Row(
+                        children: <Widget>[
+                          SizedBox(
+                            width: 95,
+                            child: ElevatedButton.icon(
+                              onPressed: () {},
+                              label: const Text('Icon'),
+                              icon: const Icon(Icons.hearing_outlined),
                             ),
-                            const SizedBox(width: 15),
-                            ToggleButtons(
-                              isSelected: const [true, false, false],
-                              children: const [
-                                Text('Off'),
-                                Text('Off'),
-                                Text('Off')
-                              ],
+                          ),
+                          const SizedBox(width: 15),
+                          SizedBox(
+                            width: 95,
+                            child: ElevatedButton.icon(
+                              onPressed: null,
+                              label: const Text('Icon'),
+                              icon: const Icon(Icons.hearing_outlined),
                             ),
-                          ],
-                        ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(
+                        children: [
+                          ToggleButtons(
+                            isSelected: _toggleButtons,
+                            onPressed: (v) => updateBoolList(_toggleButtons, v),
+                            children: [
+                              for (final v in _toggleButtons)
+                                Text(v ? 'On' : 'Off'),
+                            ],
+                          ),
+                          const SizedBox(width: 15),
+                          ToggleButtons(
+                            isSelected: const [true, false, false],
+                            children: const [
+                              Text('Off'),
+                              Text('Off'),
+                              Text('Off')
+                            ],
+                          ),
+                        ],
                       ),
                     ),
                     Padding(

--- a/example/lib/view/home_page.dart
+++ b/example/lib/view/home_page.dart
@@ -47,26 +47,19 @@ class HomePageState extends State<HomePage> {
         selectIndex: selectIndex,
       ),
       appBar: AppBar(
-        title: SizedBox(
-          width: 50,
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: TextButton(
-              style: TextButton.styleFrom(
-                padding: const EdgeInsets.all(0),
-                shape: const CircleBorder(),
-              ),
-              onPressed: () => AppTheme.apply(
-                context,
-                themeMode: theme.themeMode == ThemeMode.light
-                    ? ThemeMode.dark
-                    : ThemeMode.light,
-              ),
-              child: Icon(
-                theme.themeMode == ThemeMode.light
-                    ? Icons.dark_mode
-                    : Icons.light_mode,
-              ),
+        title: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: IconButton(
+            onPressed: () => AppTheme.apply(
+              context,
+              themeMode: theme.themeMode == ThemeMode.light
+                  ? ThemeMode.dark
+                  : ThemeMode.light,
+            ),
+            icon: Icon(
+              theme.themeMode == ThemeMode.light
+                  ? Icons.dark_mode
+                  : Icons.light_mode,
             ),
           ),
         ),

--- a/example/lib/view/inputs_view.dart
+++ b/example/lib/view/inputs_view.dart
@@ -61,7 +61,6 @@ class _InputsViewState extends State<InputsView> {
                     size: 16,
                   ),
                 ),
-                prefixIconConstraints: BoxConstraints(minHeight: 100),
                 hintText: 'Awesome Textfield',
                 labelText: 'Awesome Textfield',
               ),
@@ -79,6 +78,8 @@ class _InputsViewState extends State<InputsView> {
           const TextField(
             decoration: InputDecoration(
               labelText: 'Username',
+              prefixText: 'My Cool Prefix: ',
+              suffixText: ' your nice Suffix',
             ),
           ),
           const SizedBox(height: 15),

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -102,7 +102,14 @@ const _tooltipThemeData = TooltipThemeData(
 
 const _commonButtonStyle = ButtonStyle(
   visualDensity: VisualDensity.standard,
-  padding: MaterialStatePropertyAll(EdgeInsets.symmetric(horizontal: 16)),
+  padding: MaterialStatePropertyAll(EdgeInsets.symmetric(horizontal: 0)),
+  maximumSize: MaterialStatePropertyAll(
+    Size(kButtonHeight, double.infinity),
+  ),
+  minimumSize: MaterialStatePropertyAll(
+    Size(kButtonHeight, kButtonHeight),
+  ),
+  iconSize: MaterialStatePropertyAll(kButtonIconsHeight),
 );
 
 final _buttonThemeData = ButtonThemeData(
@@ -188,6 +195,12 @@ FilledButtonThemeData _createFilledButtonTheme(
 
 ToggleButtonsThemeData _createToggleButtonsTheme(ColorScheme colorScheme) {
   return ToggleButtonsThemeData(
+    constraints: const BoxConstraints(
+      minHeight: kButtonHeight,
+      minWidth: kButtonHeight,
+      maxWidth: double.infinity,
+      maxHeight: kButtonHeight,
+    ),
     borderRadius: const BorderRadius.all(Radius.circular(kButtonRadius)),
     borderColor: colorScheme.isHighContrast
         ? colorScheme.outlineVariant

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -43,6 +43,7 @@ AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
 InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
   final radius = BorderRadius.circular(kButtonRadius);
   const width = 1.0;
+  const strokeAlign = 0.0;
   final fill = colorScheme.isLight
       ? const Color(0xFFededed)
       : const Color.fromARGB(255, 40, 40, 40);
@@ -52,6 +53,14 @@ InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
   final disabledBorder = colorScheme.isLight
       ? const Color.fromARGB(255, 237, 237, 237)
       : const Color.fromARGB(255, 67, 67, 67);
+
+  const textStyle = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.normal,
+    textBaseline: TextBaseline.alphabetic,
+    leadingDistribution: TextLeadingDistribution.proportional,
+  );
+
   return InputDecorationTheme(
     filled: true,
     fillColor: fill,
@@ -67,23 +76,51 @@ InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
       borderRadius: radius,
     ),
     enabledBorder: OutlineInputBorder(
+      borderSide:
+          BorderSide(width: width, color: border, strokeAlign: strokeAlign),
+      borderRadius: radius,
+    ),
+    activeIndicatorBorder:
+        const BorderSide(width: width, strokeAlign: strokeAlign),
+    outlineBorder: const BorderSide(width: width, strokeAlign: strokeAlign),
+    focusedErrorBorder: OutlineInputBorder(
       borderSide: BorderSide(
         width: width,
-        color: border,
+        color: colorScheme.error,
+        strokeAlign: strokeAlign,
       ),
       borderRadius: radius,
     ),
     errorBorder: OutlineInputBorder(
-      borderSide: BorderSide(width: width, color: colorScheme.error),
+      borderSide: BorderSide(
+        width: width,
+        color: colorScheme.error,
+        strokeAlign: strokeAlign,
+      ),
       borderRadius: radius,
     ),
     disabledBorder: OutlineInputBorder(
-      borderSide: BorderSide(width: width, color: disabledBorder),
+      borderSide: BorderSide(
+        width: width,
+        color: disabledBorder,
+        strokeAlign: strokeAlign,
+      ),
       borderRadius: radius,
     ),
     isDense: true,
     iconColor: colorScheme.onSurface,
-    contentPadding: const EdgeInsets.all(12),
+    contentPadding:
+        const EdgeInsets.only(left: 12, right: 12, bottom: 9, top: 10),
+    constraints: const BoxConstraints(minHeight: 35, maxHeight: 60),
+    helperStyle: textStyle,
+    hintStyle: textStyle,
+    labelStyle: textStyle,
+    suffixStyle: textStyle.copyWith(
+      color: colorScheme.onSurface.scale(lightness: -0.2),
+    ),
+    prefixStyle: textStyle.copyWith(
+      color: colorScheme.onSurface.scale(lightness: -0.2),
+    ),
   );
 }
 

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -5,4 +5,6 @@ const kCheckRadius = 3.0;
 const kWindowRadius = 8.0;
 const kAppBarElevation = 0.0;
 const kAppBarHeight = 47.0;
+const kButtonHeight = 35.0;
+const kButtonIconsHeight = 16.0;
 const kDisabledGreyDark = Color(0xFF535353);


### PR DESCRIPTION
This is setting the height for buttons and togglebuttons to 35
The matching icon size seems to be 16 🤷 
I adapted the example (the control view really needs some love to reduce code copy pasting at some point)


![Bildschirmfoto 2023-07-21 um 11 53 30](https://github.com/ubuntu/yaru.dart/assets/15329494/1f25204b-d7dd-4a99-9344-7600c7315554)

Fixes #369