### PR TITLE
fix: remove spacing for font styles

### DIFF
--- a/lib/src/text/text_theme.dart
+++ b/lib/src/text/text_theme.dart
@@ -4,13 +4,11 @@ TextTheme createTextTheme(Color textColor) {
   return TextTheme(
     displayLarge: _UbuntuTextStyle(
       fontSize: 96,
-      letterSpacing: -1.5,
       fontWeight: FontWeight.w300,
       textColor: textColor,
     ),
     displayMedium: _UbuntuTextStyle(
       fontSize: 60,
-      letterSpacing: -0.5,
       fontWeight: FontWeight.w300,
       textColor: textColor,
     ),
@@ -31,61 +29,51 @@ TextTheme createTextTheme(Color textColor) {
     ),
     headlineSmall: _UbuntuTextStyle(
       fontSize: 24,
-      letterSpacing: -0.18,
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),
     titleLarge: _UbuntuTextStyle(
       fontSize: 20,
-      letterSpacing: 0.15,
       fontWeight: FontWeight.w500,
       textColor: textColor,
     ),
     titleMedium: _UbuntuTextStyle(
       fontSize: 16,
-      letterSpacing: 0.15,
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),
     titleSmall: _UbuntuTextStyle(
       fontSize: 14,
-      letterSpacing: 0.1,
       fontWeight: FontWeight.w500,
       textColor: textColor,
     ),
     bodyLarge: _UbuntuTextStyle(
       fontSize: 16,
-      letterSpacing: 0.5,
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),
     bodyMedium: _UbuntuTextStyle(
       fontSize: 14,
-      letterSpacing: 0.25,
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),
     bodySmall: _UbuntuTextStyle(
       fontSize: 12,
-      letterSpacing: 0.4,
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),
     labelLarge: _UbuntuTextStyle(
       fontSize: 14,
-      letterSpacing: 0.25,
       fontWeight: FontWeight.w500,
       textColor: textColor,
     ),
     labelMedium: _UbuntuTextStyle(
       fontSize: 12,
-      letterSpacing: 0.25,
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),
     labelSmall: _UbuntuTextStyle(
       fontSize: 10,
-      letterSpacing: 1.5,
       fontWeight: FontWeight.normal,
       textColor: textColor,
     ),
@@ -96,7 +84,6 @@ class _UbuntuTextStyle extends TextStyle {
   final Color textColor;
   const _UbuntuTextStyle({
     super.fontSize,
-    super.letterSpacing,
     super.fontWeight,
     required this.textColor,
   }) : super(


### PR DESCRIPTION


| Before | After |
| - | - |
| ![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/8a7f2ae7-a585-44f2-9da7-4a0b94c32b1f) |![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/94d24a17-18aa-4593-bb38-028da827a4db)|

[Bildschirmaufzeichnung vom 2023-07-28, 12-11-26.webm](https://github.com/ubuntu/yaru.dart/assets/15329494/231d2ed8-fe16-437f-8785-ccae9d19a963)



Fixes #367