### PR TITLE
feat: make dark theme darker

### DIFF
--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -89,6 +89,9 @@ class YaruColors {
   /// Jet
   static const Color jet = Color(0xFF2B2B2B);
 
+  /// Dark Jet
+  static const Color darkJet = Color(0xFF252525);
+
   /// Light title bar
   static const Color titleBarLight = Color(0xFFEBEBEB);
 

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -204,7 +204,7 @@ ToggleButtonsThemeData _createToggleButtonsTheme(ColorScheme colorScheme) {
 
 DialogTheme _createDialogTheme(ColorScheme colorScheme) {
   final bgColor = colorScheme.brightness == Brightness.dark
-      ? YaruColors.jet
+      ? YaruColors.darkJet
       : YaruColors.porcelain;
   return DialogTheme(
     backgroundColor: bgColor,
@@ -645,7 +645,7 @@ ThemeData createYaruDarkTheme({
         elevatedButtonColor?.withOpacity(0.4) ?? primaryColor.withOpacity(0.4),
     onSecondaryContainer:
         highContrast ? Colors.white : (elevatedButtonTextColor ?? Colors.white),
-    background: YaruColors.jet,
+    background: YaruColors.darkJet,
     onBackground: YaruColors.porcelain,
     surface: YaruColors.jet,
     onSurface: YaruColors.porcelain,


### PR DESCRIPTION
This PR adds a darker version of Jet (`#2b2b2b`) which is "Dark Jet"  `#252525` and applies it as the material theme's background color.

There are two main colours for things in the background in material themes

- surface, used for sidebars, appbars, bottombars, etc
- background, used for the scaffold background color mainly

Reasons why I think this is better:

- the content of windows can now have a better contrast if wanted, previously there was only 1 colour for backgrounds
- in comparison to GTK4 windows flutter windows look less bright overall (in average)

| Before | After |
| - | - |
|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/edfb7693-711e-42c4-93de-d5d525ae3781)|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/3673f0c4-37ea-424d-b1e2-326039a4bf97)|
|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/0bade3f3-5b92-497f-a4d7-0533dd5157c0)|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/a31984b1-bf1c-4582-81fe-71e7a09ba264)|
|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/4e240cee-4dbc-4774-82df-5bb47dde5771)|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/4e240cee-4dbc-4774-82df-5bb47dde5771)|

Please everyone involved have a look and say what you think
@Jupi007 @jpnurmi @madsrh @elioqoshi 

Note: the textfields now are light against dark and before dark against light, this could need fixing if you want

Fixes #234