### PR TITLE
fix: remove appbar height

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -24,7 +24,6 @@ AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
     ),
     scrolledUnderElevation: kAppBarElevation,
     surfaceTintColor: colorScheme.surface,
-    toolbarHeight: kAppBarHeight,
     elevation: kAppBarElevation,
     systemOverlayStyle: colorScheme.isLight
         ? SystemUiOverlayStyle.light

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -4,5 +4,5 @@ const kButtonRadius = 6.0;
 const kCheckRadius = 3.0;
 const kWindowRadius = 8.0;
 const kAppBarElevation = 0.0;
-const kAppBarHeight = 47.0;
+
 const kDisabledGreyDark = Color(0xFF535353);


### PR DESCRIPTION
Because we have our own CSD desktop titlebar with https://github.com/ubuntu/yaru_widgets.dart/blob/main/lib/src/widgets/yaru_title_bar.dart it is no longer needed to reduce the material appbar height

Fixes #376