### PR TITLE
feat!: Better platform independent sizes

### DIFF
--- a/example/lib/src/containers/containers_view.dart
+++ b/example/lib/src/containers/containers_view.dart
@@ -1,7 +1,6 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:yaru_example/src/constants.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 
 class ContainersView extends StatefulWidget {
   const ContainersView({super.key});
@@ -13,6 +12,12 @@ class ContainersView extends StatefulWidget {
 class _ContainersViewState extends State<ContainersView> {
   var _elevation = 2.0;
   var _inDialog = true;
+  final _icons = [
+    YaruIcons.address_book,
+    YaruIcons.application_bag,
+    YaruIcons.beaker,
+    YaruIcons.calendar_important
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -61,9 +66,9 @@ class _ContainersViewState extends State<ContainersView> {
       card,
       slider,
       containerWithBorder,
-      for (var i = 0; i < 4; i++)
+      for (var i = 0; i < _icons.length; i++)
         ListTile(
-          leading: Icon(getRandomIcon()),
+          leading: Icon(_icons[i]),
           title: Text("ListTile title $i"),
           subtitle: i.isEven ? null : const Text('Subtitle'),
           trailing: const Text("Trailing"),
@@ -104,15 +109,4 @@ class _ContainersViewState extends State<ContainersView> {
       ),
     );
   }
-}
-
-IconData getRandomIcon() {
-  final Random random = Random();
-  const String chars = '0123456789ABCDEF';
-  int length = 3;
-  String hex = '0xe';
-  while (length-- > 0) {
-    hex += chars[(random.nextInt(16)) | 0];
-  }
-  return IconData(int.parse(hex), fontFamily: 'MaterialIcons');
 }

--- a/example/lib/src/containers/containers_view.dart
+++ b/example/lib/src/containers/containers_view.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:yaru_example/src/constants.dart';
 
@@ -59,6 +61,13 @@ class _ContainersViewState extends State<ContainersView> {
       card,
       slider,
       containerWithBorder,
+      for (var i = 0; i < 4; i++)
+        ListTile(
+          leading: Icon(getRandomIcon()),
+          title: Text("ListTile title $i"),
+          subtitle: i.isEven ? null : const Text('Subtitle'),
+          trailing: const Text("Trailing"),
+        )
     ];
 
     return SizedBox(
@@ -68,11 +77,20 @@ class _ContainersViewState extends State<ContainersView> {
           const SizedBox(
             height: kWrapSpacing,
           ),
-          Switch(
-            value: _inDialog,
-            onChanged: (v) => setState(
-              () => _inDialog = v,
-            ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Switch(
+                value: _inDialog,
+                onChanged: (v) => setState(
+                  () => _inDialog = v,
+                ),
+              ),
+              const SizedBox(
+                width: 10,
+              ),
+              const Text('Show in dialog'),
+            ],
           ),
           if (_inDialog)
             SimpleDialog(
@@ -86,4 +104,15 @@ class _ContainersViewState extends State<ContainersView> {
       ),
     );
   }
+}
+
+IconData getRandomIcon() {
+  final Random random = Random();
+  const String chars = '0123456789ABCDEF';
+  int length = 3;
+  String hex = '0xe';
+  while (length-- > 0) {
+    hex += chars[(random.nextInt(16)) | 0];
+  }
+  return IconData(int.parse(hex), fontFamily: 'MaterialIcons');
 }

--- a/example/lib/src/containers/containers_view.dart
+++ b/example/lib/src/containers/containers_view.dart
@@ -63,7 +63,7 @@ class _ContainersViewState extends State<ContainersView> {
 
     return SizedBox(
       width: 400,
-      child: Column(
+      child: ListView(
         children: [
           const SizedBox(
             height: kWrapSpacing,

--- a/example/lib/src/controls/buttons.dart
+++ b/example/lib/src/controls/buttons.dart
@@ -18,6 +18,7 @@ class _ButtonsState extends State<Buttons> {
 
   @override
   Widget build(BuildContext context) {
+    const icon = Icon(Icons.circle_notifications);
     final buttons = <(Widget, Widget)>[
       (
         TextButton(
@@ -58,6 +59,58 @@ class _ButtonsState extends State<Buttons> {
         const ElevatedButton(
           onPressed: null,
           child: Text('Elevated'),
+        ),
+      ),
+      (
+        ElevatedButton.icon(
+          icon: icon,
+          onPressed: () {},
+          label: const Text('Elevated'),
+        ),
+        ElevatedButton.icon(
+          icon: icon,
+          onPressed: null,
+          label: const Text('Elevated'),
+        ),
+      ),
+      (
+        IconButton.filled(
+          onPressed: () {},
+          icon: icon,
+        ),
+        const IconButton.filled(
+          onPressed: null,
+          icon: icon,
+        ),
+      ),
+      (
+        IconButton.outlined(
+          onPressed: () {},
+          icon: icon,
+        ),
+        const IconButton.outlined(
+          onPressed: null,
+          icon: icon,
+        ),
+      ),
+      (
+        IconButton.filledTonal(
+          onPressed: () {},
+          icon: icon,
+        ),
+        const IconButton.filledTonal(
+          onPressed: null,
+          icon: icon,
+        ),
+      ),
+      (
+        IconButton(
+          onPressed: () {},
+          icon: icon,
+        ),
+        const IconButton(
+          onPressed: null,
+          icon: icon,
         ),
       ),
     ];

--- a/example/lib/src/controls/buttons.dart
+++ b/example/lib/src/controls/buttons.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:yaru_example/src/constants.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 
 class Buttons extends StatefulWidget {
   const Buttons({super.key});
@@ -18,7 +19,7 @@ class _ButtonsState extends State<Buttons> {
 
   @override
   Widget build(BuildContext context) {
-    const icon = Icon(Icons.circle_notifications);
+    const icon = Icon(YaruIcons.notification_filled);
     final buttons = <(Widget, Widget)>[
       (
         TextButton(

--- a/example/lib/src/controls/fabs.dart
+++ b/example/lib/src/controls/fabs.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:yaru_example/src/constants.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 
 class Fabs extends StatelessWidget {
   const Fabs({super.key});
@@ -15,7 +16,7 @@ class Fabs extends StatelessWidget {
       children: [
         FloatingActionButton(
           onPressed: onPressed,
-          child: const Icon(Icons.plus_one),
+          child: const Icon(YaruIcons.plus),
         ),
         FloatingActionButton.extended(
           onPressed: onPressed,
@@ -23,11 +24,11 @@ class Fabs extends StatelessWidget {
         ),
         FloatingActionButton.small(
           onPressed: onPressed,
-          child: const Icon(Icons.plus_one),
+          child: const Icon(YaruIcons.plus),
         ),
         FloatingActionButton.large(
           onPressed: onPressed,
-          child: const Icon(Icons.plus_one),
+          child: const Icon(YaruIcons.plus),
         ),
       ],
     );

--- a/example/lib/src/home/home_page.dart
+++ b/example/lib/src/home/home_page.dart
@@ -8,6 +8,7 @@ import 'package:yaru_example/src/controls/controls_view.dart';
 import 'package:yaru_example/src/fonts/fonts_view.dart';
 import 'package:yaru_example/src/home/color_disk.dart';
 import 'package:yaru_example/src/textfields/text_fields_view.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 
 final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
 
@@ -27,32 +28,32 @@ class HomePageState extends State<HomePage> {
     const FontsView(): (
       const Badge(
         label: Text('123'),
-        child: Icon(Icons.font_download_outlined),
+        child: Icon(YaruIcons.font),
       ),
       const Badge(
         label: Text('123'),
-        child: Icon(Icons.font_download),
+        child: Icon(YaruIcons.font),
       ),
       'Fonts'
     ),
     const ControlsView(): (
-      const Icon(Icons.radio_button_checked_outlined),
-      const Icon(Icons.radio_button_checked),
+      const Icon(YaruIcons.radiobox_checked),
+      const Icon(YaruIcons.radiobox_checked_filled),
       'Controls'
     ),
     const TextFieldsView(): (
-      const Icon(Icons.text_fields_outlined),
-      const Icon(Icons.text_fields),
+      const Icon(YaruIcons.text_editor),
+      const Icon(YaruIcons.text_editor_filled),
       'TextFields'
     ),
     const ColorsView(): (
-      const Icon(Icons.color_lens_outlined),
-      const Icon(Icons.color_lens),
+      const Icon(YaruIcons.colors),
+      const Icon(YaruIcons.colors_filled),
       'Palette'
     ),
     const ContainersView(): (
-      const Icon(Icons.square_outlined),
-      const Icon(Icons.square),
+      const Icon(YaruIcons.window),
+      const Icon(YaruIcons.window_filled),
       'Containers'
     ),
   };
@@ -73,7 +74,7 @@ class HomePageState extends State<HomePage> {
         leading: Center(
           child: IconButton(
             onPressed: () => _scaffoldKey.currentState?.openDrawer(),
-            icon: const Icon(Icons.menu),
+            icon: const Icon(YaruIcons.menu),
           ),
         ),
         title: const _Title(),
@@ -156,7 +157,7 @@ class _ThemeButton extends StatelessWidget {
     return PopupMenuButton<Color>(
       padding: EdgeInsets.zero,
       icon: Icon(
-        Icons.color_lens,
+        YaruIcons.color_select,
         color: Theme.of(context).primaryColor,
       ),
       itemBuilder: (context) {
@@ -213,7 +214,7 @@ class _Title extends StatelessWidget {
         );
       },
       icon: Icon(
-        light ? Icons.light_mode : Icons.dark_mode,
+        light ? YaruIcons.sun_filled : YaruIcons.clear_night_filled,
       ),
     );
   }

--- a/example/lib/src/home/home_page.dart
+++ b/example/lib/src/home/home_page.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_example/main.dart';
-import 'package:yaru_example/src/constants.dart';
-import 'package:yaru_example/src/home/color_disk.dart';
 import 'package:yaru_example/src/colors/colors_view.dart';
+import 'package:yaru_example/src/constants.dart';
 import 'package:yaru_example/src/containers/containers_view.dart';
 import 'package:yaru_example/src/controls/controls_view.dart';
 import 'package:yaru_example/src/fonts/fonts_view.dart';
+import 'package:yaru_example/src/home/color_disk.dart';
 import 'package:yaru_example/src/textfields/text_fields_view.dart';
 
 final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
@@ -154,6 +154,7 @@ class _ThemeButton extends StatelessWidget {
     final light = theme.themeMode == ThemeMode.light;
 
     return PopupMenuButton<Color>(
+      padding: EdgeInsets.zero,
       icon: Icon(
         Icons.color_lens,
         color: Theme.of(context).primaryColor,

--- a/example/lib/src/home/home_page.dart
+++ b/example/lib/src/home/home_page.dart
@@ -9,6 +9,8 @@ import 'package:yaru_example/src/controls/controls_view.dart';
 import 'package:yaru_example/src/fonts/fonts_view.dart';
 import 'package:yaru_example/src/textfields/text_fields_view.dart';
 
+final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
+
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
 
@@ -58,6 +60,7 @@ class HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      key: _scaffoldKey,
       drawer: _Drawer(
         selectedIndex: _selectedIndex,
         onSelected: (index) {
@@ -67,6 +70,12 @@ class HomePageState extends State<HomePage> {
         items: _items,
       ),
       appBar: AppBar(
+        leading: Center(
+          child: IconButton(
+            onPressed: () => _scaffoldKey.currentState?.openDrawer(),
+            icon: const Icon(Icons.menu),
+          ),
+        ),
         title: const _Title(),
         actions: const [
           Padding(

--- a/example/lib/src/textfields/text_fields_view.dart
+++ b/example/lib/src/textfields/text_fields_view.dart
@@ -32,6 +32,18 @@ class _TextFieldsViewState extends State<TextFieldsView> {
       Row(
         children: [
           Expanded(
+            child: FilledButton(
+              onPressed: () {},
+              child: const Text(
+                'Filled Button',
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+          const SizedBox(
+            width: kWrapSpacing,
+          ),
+          Expanded(
             child: OutlinedButton(
               onPressed: () {},
               child: const Text(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   handy_window: ^0.3.1
   yaru:
     path: ../
+  yaru_icons: ^2.1.0
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -21,6 +21,7 @@ AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
   return AppBarTheme(
     shape: Border(
       bottom: BorderSide(
+        strokeAlign: -1,
         color: colorScheme.isHighContrast
             ? colorScheme.outlineVariant
             : colorScheme.onSurface.withOpacity(

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -574,6 +574,9 @@ DropdownMenuThemeData _createDropdownMenuTheme(ColorScheme colorScheme) {
 
 NavigationBarThemeData _createNavigationBarTheme(ColorScheme colorScheme) {
   return NavigationBarThemeData(
+    height: isMobile
+        ? kComfortableNavigationBarHeight
+        : kCompactNavigationBarHeight,
     backgroundColor: colorScheme.surface,
     surfaceTintColor: colorScheme.surface,
     indicatorColor: colorScheme.onSurface.withOpacity(0.1),

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -246,6 +246,7 @@ FilledButtonThemeData _createFilledButtonTheme(
 IconButtonThemeData _createIconButtonTheme(ColorScheme colorScheme) {
   return IconButtonThemeData(
     style: IconButton.styleFrom(
+      padding: isMobile ? null : EdgeInsets.zero,
       foregroundColor: colorScheme.onSurface,
       highlightColor: colorScheme.onSurface.withOpacity(0.05),
       surfaceTintColor: colorScheme.background,

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:yaru/src/colors.dart';
@@ -8,6 +11,9 @@ import 'package:yaru/src/themes/page_transitions.dart';
 
 const kDividerColorDark = Color.fromARGB(255, 65, 65, 65);
 const kDividerColorLight = Color(0xffdcdcdc);
+
+bool get isMobile =>
+    !kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isFuchsia);
 
 // AppBar
 
@@ -34,14 +40,19 @@ AppBarTheme _createAppBarTheme(ColorScheme colorScheme) {
           color: colorScheme.onSurface,
           fontWeight: FontWeight.normal,
         ),
-    iconTheme: IconThemeData(color: colorScheme.onSurface),
+    iconTheme: IconThemeData(
+      color: colorScheme.onSurface,
+      size: isMobile ? kComfortableIconSize : kCompactIconSize,
+    ),
     actionsIconTheme: IconThemeData(color: colorScheme.onSurface),
+    toolbarHeight: isMobile ? kComfortableAppBarHeight : kCompactAppBarHeight,
   );
 }
 
 InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
   final radius = BorderRadius.circular(kButtonRadius);
   const width = 1.0;
+  const strokeAlign = 0.0;
   final fill = colorScheme.isLight
       ? const Color(0xFFededed)
       : const Color.fromARGB(255, 40, 40, 40);
@@ -51,6 +62,12 @@ InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
   final disabledBorder = colorScheme.isLight
       ? const Color.fromARGB(255, 237, 237, 237)
       : const Color.fromARGB(255, 67, 67, 67);
+
+  const textStyle = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.normal,
+  );
+
   return InputDecorationTheme(
     filled: true,
     fillColor: fill,
@@ -66,23 +83,55 @@ InputDecorationTheme _createInputDecorationTheme(ColorScheme colorScheme) {
       borderRadius: radius,
     ),
     enabledBorder: OutlineInputBorder(
+      borderSide:
+          BorderSide(width: width, color: border, strokeAlign: strokeAlign),
+      borderRadius: radius,
+    ),
+    activeIndicatorBorder:
+        const BorderSide(width: width, strokeAlign: strokeAlign),
+    outlineBorder: const BorderSide(width: width, strokeAlign: strokeAlign),
+    focusedErrorBorder: OutlineInputBorder(
       borderSide: BorderSide(
         width: width,
-        color: border,
+        color: colorScheme.error,
+        strokeAlign: strokeAlign,
       ),
       borderRadius: radius,
     ),
     errorBorder: OutlineInputBorder(
-      borderSide: BorderSide(width: width, color: colorScheme.error),
+      borderSide: BorderSide(
+        width: width,
+        color: colorScheme.error,
+        strokeAlign: strokeAlign,
+      ),
       borderRadius: radius,
     ),
     disabledBorder: OutlineInputBorder(
-      borderSide: BorderSide(width: width, color: disabledBorder),
+      borderSide: BorderSide(
+        width: width,
+        color: disabledBorder,
+        strokeAlign: strokeAlign,
+      ),
       borderRadius: radius,
     ),
-    isDense: true,
+    isDense: isMobile ? false : true,
     iconColor: colorScheme.onSurface,
-    contentPadding: const EdgeInsets.all(12),
+    contentPadding: isMobile
+        ? const EdgeInsets.all(12)
+        : const EdgeInsets.only(left: 12, right: 12, bottom: 9, top: 10),
+    helperStyle: isMobile ? null : textStyle,
+    hintStyle: isMobile ? null : textStyle,
+    labelStyle: isMobile ? null : textStyle,
+    suffixStyle: isMobile
+        ? null
+        : textStyle.copyWith(
+            color: colorScheme.onSurface.scale(lightness: -0.2),
+          ),
+    prefixStyle: isMobile
+        ? null
+        : textStyle.copyWith(
+            color: colorScheme.onSurface.scale(lightness: -0.2),
+          ),
   );
 }
 
@@ -99,9 +148,18 @@ const _tooltipThemeData = TooltipThemeData(
 
 // Buttons
 
-const _commonButtonStyle = ButtonStyle(
-  visualDensity: VisualDensity.standard,
-  padding: MaterialStatePropertyAll(EdgeInsets.symmetric(horizontal: 16)),
+final _commonButtonStyle = ButtonStyle(
+  padding: isMobile
+      ? const MaterialStatePropertyAll(
+          EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 18,
+          ),
+        )
+      : const MaterialStatePropertyAll(EdgeInsets.all(16)),
+  iconSize: isMobile
+      ? const MaterialStatePropertyAll(kComfortableButtonIconSize)
+      : const MaterialStatePropertyAll(kCompactButtonIconSize),
 );
 
 final _buttonThemeData = ButtonThemeData(
@@ -185,8 +243,69 @@ FilledButtonThemeData _createFilledButtonTheme(
   );
 }
 
+IconButtonThemeData _createIconButtonTheme(ColorScheme colorScheme) {
+  return IconButtonThemeData(
+    style: IconButton.styleFrom(
+      foregroundColor: colorScheme.onSurface,
+      highlightColor: colorScheme.onSurface.withOpacity(0.05),
+      surfaceTintColor: colorScheme.background,
+      fixedSize: isMobile
+          ? null
+          : const Size(kCompactButtonHeight, kCompactButtonHeight),
+      minimumSize: isMobile
+          ? null
+          : const Size(kCompactButtonHeight, kCompactButtonHeight),
+      maximumSize: isMobile
+          ? null
+          : const Size(kCompactButtonHeight, kCompactButtonHeight),
+      tapTargetSize: isMobile
+          ? MaterialTapTargetSize.padded
+          : MaterialTapTargetSize.shrinkWrap,
+      iconSize: isMobile ? kComfortableIconSize : kCompactIconSize,
+    ),
+  );
+}
+
+MenuButtonThemeData _createMenuItemTheme(
+  ColorScheme colorScheme,
+  TextTheme textTheme,
+) {
+  return MenuButtonThemeData(
+    style: ButtonStyle(
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      alignment: Alignment.center,
+      textStyle: MaterialStatePropertyAll(textTheme.bodyMedium),
+      maximumSize: MaterialStatePropertyAll(
+        Size(
+          999,
+          (isMobile ? kComfortableButtonHeight : kCompactButtonHeight) + 10,
+        ),
+      ),
+      minimumSize: MaterialStatePropertyAll(
+        Size(
+          20,
+          (isMobile ? kComfortableButtonHeight : kCompactButtonHeight) + 10,
+        ),
+      ),
+    ),
+  );
+}
+
 ToggleButtonsThemeData _createToggleButtonsTheme(ColorScheme colorScheme) {
   return ToggleButtonsThemeData(
+    constraints: isMobile
+        ? const BoxConstraints(
+            minHeight: kComfortableButtonHeight,
+            minWidth: 60,
+            maxWidth: double.infinity,
+            maxHeight: kComfortableButtonHeight,
+          )
+        : const BoxConstraints(
+            minHeight: kCompactButtonHeight,
+            minWidth: 50,
+            maxWidth: double.infinity,
+            maxHeight: kCompactButtonHeight,
+          ),
     borderRadius: const BorderRadius.all(Radius.circular(kButtonRadius)),
     borderColor: colorScheme.isHighContrast
         ? colorScheme.outlineVariant
@@ -441,7 +560,12 @@ MenuThemeData _createMenuTheme(ColorScheme colorScheme) {
 
 DropdownMenuThemeData _createDropdownMenuTheme(ColorScheme colorScheme) {
   return DropdownMenuThemeData(
-    inputDecorationTheme: _createInputDecorationTheme(colorScheme),
+    inputDecorationTheme: _createInputDecorationTheme(colorScheme).copyWith(
+      constraints: BoxConstraints(
+        maxHeight: isMobile ? kComfortableButtonHeight : kCompactButtonHeight,
+        minHeight: isMobile ? kComfortableButtonHeight : kCompactButtonHeight,
+      ),
+    ),
     menuStyle: _createMenuStyle(colorScheme),
   );
 }
@@ -463,9 +587,13 @@ NavigationRailThemeData _createNavigationRailTheme(ColorScheme colorScheme) {
   return NavigationRailThemeData(
     backgroundColor: colorScheme.surface,
     indicatorColor: colorScheme.onSurface.withOpacity(0.1),
-    selectedIconTheme: IconThemeData(color: colorScheme.onSurface),
+    selectedIconTheme: IconThemeData(
+      color: colorScheme.onSurface,
+      size: isMobile ? kComfortableIconSize : kCompactIconSize,
+    ),
     unselectedIconTheme: IconThemeData(
       color: colorScheme.onSurface.withOpacity(0.8),
+      size: isMobile ? kComfortableIconSize : kCompactIconSize,
     ),
   );
 }
@@ -496,18 +624,15 @@ ThemeData createYaruTheme({
   dividerColor ??= colorScheme.isHighContrast
       ? colorScheme.outlineVariant
       : colorScheme.outline;
+  final textTheme = createTextTheme(colorScheme.onSurface);
   return ThemeData.from(
     useMaterial3: useMaterial3,
     colorScheme: colorScheme,
   ).copyWith(
-    iconButtonTheme: IconButtonThemeData(
-      style: IconButton.styleFrom(
-        foregroundColor: colorScheme.onSurface,
-        highlightColor: colorScheme.onSurface.withOpacity(0.05),
-        surfaceTintColor: colorScheme.background,
-      ),
+    iconTheme: IconThemeData(
+      color: colorScheme.onSurface,
+      size: isMobile ? kComfortableIconSize : kCompactIconSize,
     ),
-    iconTheme: IconThemeData(color: colorScheme.onSurface),
     primaryIconTheme: IconThemeData(color: colorScheme.onSurface),
     progressIndicatorTheme: _createProgressIndicatorTheme(colorScheme),
     pageTransitionsTheme: YaruPageTransitionsTheme.horizontal,
@@ -520,7 +645,7 @@ ThemeData createYaruTheme({
     cardColor: colorScheme.surface,
     dividerColor: dividerColor,
     dialogBackgroundColor: colorScheme.background,
-    textTheme: createTextTheme(colorScheme.onSurface),
+    textTheme: textTheme,
     indicatorColor: colorScheme.primary,
     applyElevationOverlayColor: colorScheme.isDark,
     buttonTheme: _buttonThemeData,
@@ -534,6 +659,8 @@ ThemeData createYaruTheme({
       colorScheme,
     ),
     textButtonTheme: _createTextButtonTheme(colorScheme),
+    iconButtonTheme: _createIconButtonTheme(colorScheme),
+    menuButtonTheme: _createMenuItemTheme(colorScheme, textTheme),
     switchTheme: _createSwitchTheme(colorScheme),
     checkboxTheme: _createCheckBoxTheme(colorScheme),
     radioTheme: _createRadioTheme(colorScheme),

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -7,7 +7,7 @@ const kComfortableAppBarHeight = 56.0;
 
 const kCompactButtonHeight = 35.0;
 const kComfortableButtonHeight = 48.0;
-const kCompactButtonIconSize = 16.0;
-const kComfortableButtonIconSize = 22.0;
-const kCompactIconSize = 19.0;
-const kComfortableIconSize = 22.0;
+const kCompactButtonIconSize = 20.0;
+const kComfortableButtonIconSize = 24.0;
+const kCompactIconSize = 20.0;
+const kComfortableIconSize = 24.0;

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -4,6 +4,8 @@ const kWindowRadius = 8.0;
 const kAppBarElevation = 0.0;
 const kCompactAppBarHeight = 46.0;
 const kComfortableAppBarHeight = 56.0;
+const kCompactNavigationBarHeight = 64.0;
+const kComfortableNavigationBarHeight = 74.0;
 
 const kCompactButtonHeight = 34.0;
 const kComfortableButtonHeight = 44.0;

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -2,11 +2,11 @@ const kButtonRadius = 6.0;
 const kCheckRadius = 3.0;
 const kWindowRadius = 8.0;
 const kAppBarElevation = 0.0;
-const kCompactAppBarHeight = 47.0;
+const kCompactAppBarHeight = 46.0;
 const kComfortableAppBarHeight = 56.0;
 
-const kCompactButtonHeight = 35.0;
-const kComfortableButtonHeight = 48.0;
+const kCompactButtonHeight = 34.0;
+const kComfortableButtonHeight = 44.0;
 const kCompactButtonIconSize = 20.0;
 const kComfortableButtonIconSize = 24.0;
 const kCompactIconSize = 20.0;

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -1,8 +1,13 @@
-import 'dart:ui';
-
 const kButtonRadius = 6.0;
 const kCheckRadius = 3.0;
 const kWindowRadius = 8.0;
 const kAppBarElevation = 0.0;
+const kCompactAppBarHeight = 47.0;
+const kComfortableAppBarHeight = 56.0;
 
-const kDisabledGreyDark = Color(0xFF535353);
+const kCompactButtonHeight = 35.0;
+const kComfortableButtonHeight = 48.0;
+const kCompactButtonIconSize = 16.0;
+const kComfortableButtonIconSize = 22.0;
+const kCompactIconSize = 19.0;
+const kComfortableIconSize = 22.0;


### PR DESCRIPTION
Since the VisualDensity API is kinda incomplete, I made a custom solution with `bool get isMobile =>
    !kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isFuchsia);` 

Web is excluded because when compared to for example github, the compact widgets fit much better.
While on it I discovered a lot if themes we did not include yet :laughing: 
I also discovered :monocle_face: IconButton.outlined, .tonal and .filled
Which have a flipped color but this is a different topic for a different PR and switching the green to filled will prbly break a lot of apps, so let's not do this now.

However the compact sizes should fit us very well but I guess we need to test this a bit.

Some screenshots...

Since the colors are untouched I only show the dark theme:

| Comfortable | Compact |
| -| -|
|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/a33d09c8-bbc4-45d8-9f4c-325f4ceb6f4d)|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/a7434d14-921f-433d-81dd-097ac092fc8a)|
|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/ef679701-4534-4c48-ae45-0322b66336f8)|![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/17f62a12-6236-40d8-b22b-a1406fe8a527)|



Fixes #369