### PR TITLE
fix: reduce dark snackbar border brightness

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -638,7 +638,7 @@ SnackBarThemeData _createSnackBarTheme(ColorScheme colorScheme) {
       side: light
           ? BorderSide.none
           : BorderSide(
-              color: fg.withOpacity(0.25),
+              color: fg.withOpacity(0.2),
               width: 1,
             ),
     ),

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -622,7 +622,7 @@ SnackBarThemeData _createSnackBarTheme(ColorScheme colorScheme) {
   final light = colorScheme.brightness == Brightness.light;
   const fg = Colors.white;
   return SnackBarThemeData(
-    backgroundColor: Colors.black.withOpacity(0.8),
+    backgroundColor: const Color.fromARGB(255, 20, 20, 20).withOpacity(0.8),
     closeIconColor: fg,
     actionTextColor: Colors.white,
     contentTextStyle: const TextStyle(color: fg),
@@ -638,7 +638,7 @@ SnackBarThemeData _createSnackBarTheme(ColorScheme colorScheme) {
       side: light
           ? BorderSide.none
           : BorderSide(
-              color: fg.withOpacity(0.2),
+              color: fg.withOpacity(0.14),
               width: 1,
             ),
     ),


### PR DESCRIPTION
sorry, now 1 review is required before merge :+1: 

![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/caafd170-2f8b-4294-9287-d1feff730ed8)

reducing the brightness a bit

should we force a width in the theme or should users chose what they want in SnackBar()?