### PR TITLE
fix: set default size for snackbars

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -622,6 +622,7 @@ SnackBarThemeData _createSnackBarTheme(ColorScheme colorScheme) {
   final light = colorScheme.brightness == Brightness.light;
   const fg = Colors.white;
   return SnackBarThemeData(
+    width: kSnackBarWidth,
     backgroundColor: const Color.fromARGB(255, 20, 20, 20).withOpacity(0.8),
     closeIconColor: fg,
     actionTextColor: Colors.white,

--- a/lib/src/themes/constants.dart
+++ b/lib/src/themes/constants.dart
@@ -6,6 +6,7 @@ const kCompactAppBarHeight = 46.0;
 const kComfortableAppBarHeight = 56.0;
 const kCompactNavigationBarHeight = 64.0;
 const kComfortableNavigationBarHeight = 74.0;
+const kSnackBarWidth = 350.0;
 
 const kCompactButtonHeight = 34.0;
 const kComfortableButtonHeight = 44.0;


### PR DESCRIPTION

![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/e4da3e58-1ced-481f-9f01-f7952fd2c763)


Fixes #388