### PR TITLE
feat!: use different shade of the same color for primary, secondary, tertiary

### DIFF
--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -251,6 +251,50 @@ extension YaruColorExtension on Color {
         .toColor();
   }
 
+  Color cap({
+    double alpha = 1.0,
+    double saturation = 1.0,
+    double lightness = 1.0,
+  }) {
+    assert(alpha >= 0.0 && alpha <= 1.0);
+    assert(saturation >= 0.0 && saturation <= 1.0);
+    assert(lightness >= 0.0 && lightness <= 1.0);
+
+    final hslColor = _getPatchedHslColor();
+
+    return hslColor
+        .withAlpha(hslColor.alpha <= alpha ? hslColor.alpha : alpha)
+        .withSaturation(
+          hslColor.saturation <= saturation ? hslColor.saturation : saturation,
+        )
+        .withLightness(
+          hslColor.lightness <= lightness ? hslColor.lightness : lightness,
+        )
+        .toColor();
+  }
+
+  Color capDown({
+    double alpha = 0.0,
+    double saturation = 0.0,
+    double lightness = 0.0,
+  }) {
+    assert(alpha >= 0.0 && alpha <= 1.0);
+    assert(saturation >= 0.0 && saturation <= 1.0);
+    assert(lightness >= 0.0 && lightness <= 1.0);
+
+    final hslColor = _getPatchedHslColor();
+
+    return hslColor
+        .withAlpha(hslColor.alpha >= alpha ? hslColor.alpha : alpha)
+        .withSaturation(
+          hslColor.saturation >= saturation ? hslColor.saturation : saturation,
+        )
+        .withLightness(
+          hslColor.lightness >= lightness ? hslColor.lightness : lightness,
+        )
+        .toColor();
+  }
+
   HSLColor _getPatchedHslColor() {
     final hslColor = HSLColor.fromColor(this);
 

--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -646,6 +646,15 @@ SnackBarThemeData _createSnackBarTheme(ColorScheme colorScheme) {
   );
 }
 
+ChipThemeData _createChipTheme({
+  required Color selectedColor,
+  required ColorScheme colorScheme,
+}) {
+  return ChipThemeData(
+    selectedColor: selectedColor.withOpacity(.4),
+  );
+}
+
 /// Helper function to create a new Yaru theme
 ThemeData createYaruTheme({
   required ColorScheme colorScheme,
@@ -730,6 +739,10 @@ ThemeData createYaruTheme({
       iconColor: colorScheme.onSurface.withOpacity(0.8),
     ),
     snackBarTheme: _createSnackBarTheme(colorScheme),
+    chipTheme: _createChipTheme(
+      selectedColor: elevatedButtonColor ?? colorScheme.primary,
+      colorScheme: colorScheme,
+    ),
   );
 }
 
@@ -740,6 +753,13 @@ ThemeData createYaruLightTheme({
   Color? elevatedButtonTextColor,
   bool? useMaterial3 = true,
 }) {
+  final secondary = primaryColor.scale(lightness: 0.2).cap(saturation: .9);
+  final secondaryContainer =
+      primaryColor.scale(lightness: 0.85).cap(saturation: .5);
+  final tertiary = primaryColor.scale(lightness: 0.5).cap(saturation: .8);
+  final tertiaryContainer =
+      primaryColor.scale(lightness: 0.75).cap(saturation: .75);
+
   final colorScheme = ColorScheme.fromSeed(
     seedColor: primaryColor,
     error: YaruColors.light.error,
@@ -750,11 +770,10 @@ ThemeData createYaruLightTheme({
     primaryContainer: YaruColors.porcelain,
     onPrimaryContainer: YaruColors.jet,
     inversePrimary: YaruColors.jet,
-    secondary: elevatedButtonColor ?? primaryColor,
-    onSecondary: contrastColor(elevatedButtonColor ?? primaryColor),
-    secondaryContainer:
-        elevatedButtonColor?.withOpacity(0.4) ?? primaryColor.withOpacity(0.4),
-    onSecondaryContainer: elevatedButtonTextColor ?? YaruColors.jet,
+    secondary: secondary,
+    onSecondary: contrastColor(secondary),
+    secondaryContainer: secondaryContainer,
+    onSecondaryContainer: contrastColor(secondaryContainer),
     background: YaruColors.porcelain,
     onBackground: YaruColors.jet,
     surface: Colors.white,
@@ -763,10 +782,10 @@ ThemeData createYaruLightTheme({
     onInverseSurface: YaruColors.porcelain,
     surfaceTint: YaruColors.warmGrey,
     surfaceVariant: YaruColors.warmGrey,
-    tertiary: const Color(0xFF18b6ec),
-    onTertiary: Colors.white,
-    tertiaryContainer: const Color(0xFF18b6ec),
-    onTertiaryContainer: Colors.white,
+    tertiary: tertiary,
+    onTertiary: contrastColor(tertiary),
+    tertiaryContainer: tertiaryContainer,
+    onTertiaryContainer: contrastColor(tertiaryContainer),
     onSurfaceVariant: YaruColors.coolGrey,
     outline: const Color.fromARGB(255, 221, 221, 221),
     outlineVariant: Colors.black,
@@ -789,6 +808,15 @@ ThemeData createYaruDarkTheme({
   bool? useMaterial3 = true,
   bool highContrast = false,
 }) {
+  final secondary = primaryColor.scale(lightness: -0.3, saturation: -0.15);
+  final secondaryContainer = primaryColor
+      .scale(lightness: -0.6, saturation: -0.75)
+      .capDown(lightness: .175);
+  final tertiary = primaryColor.scale(lightness: -0.5, saturation: -0.25);
+  final tertiaryContainer = primaryColor
+      .scale(lightness: -0.5, saturation: -0.65)
+      .capDown(lightness: .2);
+
   final colorScheme = ColorScheme.fromSeed(
     seedColor: primaryColor,
     error: YaruColors.dark.error,
@@ -799,12 +827,10 @@ ThemeData createYaruDarkTheme({
     onPrimary: contrastColor(primaryColor),
     onPrimaryContainer: YaruColors.porcelain,
     inversePrimary: YaruColors.porcelain,
-    secondary: elevatedButtonColor ?? primaryColor,
-    onSecondary: contrastColor(elevatedButtonColor ?? primaryColor),
-    secondaryContainer:
-        elevatedButtonColor?.withOpacity(0.4) ?? primaryColor.withOpacity(0.4),
-    onSecondaryContainer:
-        highContrast ? Colors.white : (elevatedButtonTextColor ?? Colors.white),
+    secondary: secondary,
+    onSecondary: contrastColor(primaryColor.scale(lightness: -0.25)),
+    secondaryContainer: secondaryContainer,
+    onSecondaryContainer: Colors.white,
     background: YaruColors.darkJet,
     onBackground: YaruColors.porcelain,
     surface: YaruColors.jet,
@@ -813,9 +839,9 @@ ThemeData createYaruDarkTheme({
     onInverseSurface: YaruColors.inkstone,
     surfaceTint: YaruColors.coolGrey,
     surfaceVariant: const Color.fromARGB(255, 34, 34, 34),
-    tertiary: const Color(0xFF18b6ec),
+    tertiary: tertiary,
     onTertiary: YaruColors.porcelain,
-    tertiaryContainer: const Color(0xFF18b6ec),
+    tertiaryContainer: tertiaryContainer,
     onTertiaryContainer: YaruColors.porcelain,
     onSurfaceVariant: YaruColors.warmGrey,
     outline: const Color.fromARGB(255, 68, 68, 68),

--- a/test/yaru_color_extension_test.dart
+++ b/test/yaru_color_extension_test.dart
@@ -199,6 +199,56 @@ void main() {
     });
   });
 
+  group('Color.cap() test -', () {
+    test('With out of range amount', () {
+      expect(() => midColor.cap(alpha: -1.1), throwsAssertionError);
+      expect(() => midColor.cap(alpha: 1.1), throwsAssertionError);
+      expect(() => midColor.cap(saturation: -1.1), throwsAssertionError);
+      expect(() => midColor.cap(saturation: 1.1), throwsAssertionError);
+      expect(() => midColor.cap(lightness: -1.1), throwsAssertionError);
+      expect(() => midColor.cap(lightness: 1.1), throwsAssertionError);
+    });
+    test('With various amount', () {
+      expect(
+        midColor.cap(alpha: 0.25),
+        const Color(0x4040bfbf),
+      );
+      expect(
+        midColor.cap(saturation: 0.25),
+        const Color(0x80609f9f),
+      );
+      expect(
+        midColor.cap(lightness: 0.25),
+        const Color(0x80206060),
+      );
+    });
+  });
+
+  group('Color.capDown() test -', () {
+    test('With out of range amount', () {
+      expect(() => midColor.capDown(alpha: -1.1), throwsAssertionError);
+      expect(() => midColor.capDown(alpha: 1.1), throwsAssertionError);
+      expect(() => midColor.capDown(saturation: -1.1), throwsAssertionError);
+      expect(() => midColor.capDown(saturation: 1.1), throwsAssertionError);
+      expect(() => midColor.capDown(lightness: -1.1), throwsAssertionError);
+      expect(() => midColor.capDown(lightness: 1.1), throwsAssertionError);
+    });
+    test('With various amount', () {
+      expect(
+        midColor.capDown(alpha: 0.75),
+        const Color(0xbf40bfbf),
+      );
+      expect(
+        midColor.capDown(saturation: 0.75),
+        const Color(0x8020dfdf),
+      );
+      expect(
+        midColor.capDown(lightness: 0.75),
+        const Color(0x80a0dfdf),
+      );
+    });
+  });
+
   test('hex', () {
     expect(const Color(0x12345678).toHex(), '#12345678');
   });


### PR DESCRIPTION
- use a different shade of the same color for primary, secondary and tertiary ;
- add cap and capDown Color extension.

| Light theme | Dark theme |
| --- | --- |
| ![Capture d’écran du 2023-08-15 18-26-33](https://github.com/ubuntu/yaru.dart/assets/36476595/cc73f548-7202-4305-9ada-b24e45638e0c) | ![Capture d’écran du 2023-08-15 18-27-30](https://github.com/ubuntu/yaru.dart/assets/36476595/f0cec95b-bd37-4c5d-a46f-46735cf6eb89)
| ![Capture d’écran du 2023-08-15 18-26-39](https://github.com/ubuntu/yaru.dart/assets/36476595/7223b8df-f8fd-4cb8-a26f-ae2eaa587015) | ![Capture d’écran du 2023-08-15 18-27-35](https://github.com/ubuntu/yaru.dart/assets/36476595/23f3e4b5-2df4-4260-a84a-597168f0ad6c)
| ![Capture d’écran du 2023-08-15 18-26-44](https://github.com/ubuntu/yaru.dart/assets/36476595/a8dd8ba3-244f-46ec-b79c-5ab32ede058c) | ![Capture d’écran du 2023-08-15 18-27-39](https://github.com/ubuntu/yaru.dart/assets/36476595/1b92131a-5f68-4d04-bb3a-519ce8a6b20b)
| ![Capture d’écran du 2023-08-15 18-26-52](https://github.com/ubuntu/yaru.dart/assets/36476595/c714de7f-098b-46f2-9381-7c8c804b6b92) | ![Capture d’écran du 2023-08-15 18-27-46](https://github.com/ubuntu/yaru.dart/assets/36476595/6a9018d6-61ee-4b3a-8a82-7143541a6cd0)
| ![Capture d’écran du 2023-08-15 18-26-58](https://github.com/ubuntu/yaru.dart/assets/36476595/1fb79d50-8009-4f2a-a29d-c214a1d5b49b) | ![Capture d’écran du 2023-08-15 18-27-50](https://github.com/ubuntu/yaru.dart/assets/36476595/14c739d2-e93d-4221-816a-9a2451642886)
| ![Capture d’écran du 2023-08-15 18-27-02](https://github.com/ubuntu/yaru.dart/assets/36476595/fa2f0dd6-8ea3-4ba1-93da-83bb215b4e48) | ![Capture d’écran du 2023-08-15 18-27-54](https://github.com/ubuntu/yaru.dart/assets/36476595/df1bf0e6-45b6-4784-ae22-4b892036fbed)
| ![Capture d’écran du 2023-08-15 18-27-06](https://github.com/ubuntu/yaru.dart/assets/36476595/434c020c-0c3a-4239-b70d-a85873a354c5) | ![Capture d’écran du 2023-08-15 18-28-00](https://github.com/ubuntu/yaru.dart/assets/36476595/eba17623-c3d3-4818-9579-4fffdecb9e7f)
| ![Capture d’écran du 2023-08-15 18-27-10](https://github.com/ubuntu/yaru.dart/assets/36476595/cc000963-7064-46a1-abc4-d1a3ae55d3bc) | ![Capture d’écran du 2023-08-15 18-28-04](https://github.com/ubuntu/yaru.dart/assets/36476595/fad0eae1-885f-4993-ac0d-fcb46d7ac3df)
| ![Capture d’écran du 2023-08-15 18-27-13](https://github.com/ubuntu/yaru.dart/assets/36476595/5fc62f83-eece-476e-ba52-8e41d4290c86) | ![Capture d’écran du 2023-08-15 18-28-09](https://github.com/ubuntu/yaru.dart/assets/36476595/3d9cf03f-4452-4d7d-a8b0-164adebc17a8)
| ![Capture d’écran du 2023-08-15 18-27-17](https://github.com/ubuntu/yaru.dart/assets/36476595/2b2d3710-5440-41b9-b0d4-cf7038f04e77) | ![Capture d’écran du 2023-08-15 18-28-13](https://github.com/ubuntu/yaru.dart/assets/36476595/7738b33c-c9d5-4b1e-bbf5-eb35d7c7cc8c)

Fixes #300