### PR TITLE
fix: snackbar visibility

### DIFF
--- a/lib/src/themes/common_themes.dart
+++ b/lib/src/themes/common_themes.dart
@@ -619,11 +619,10 @@ DrawerThemeData _createDrawerTheme(ColorScheme colorScheme) {
 }
 
 SnackBarThemeData _createSnackBarTheme(ColorScheme colorScheme) {
-  final light = colorScheme.brightness == Brightness.light;
   const fg = Colors.white;
   return SnackBarThemeData(
     width: kSnackBarWidth,
-    backgroundColor: const Color.fromARGB(255, 20, 20, 20).withOpacity(0.8),
+    backgroundColor: const Color.fromARGB(255, 20, 20, 20).withOpacity(0.95),
     closeIconColor: fg,
     actionTextColor: Colors.white,
     contentTextStyle: const TextStyle(color: fg),
@@ -636,12 +635,6 @@ SnackBarThemeData _createSnackBarTheme(ColorScheme colorScheme) {
       borderRadius: BorderRadius.circular(
         isMobile ? kComfortableButtonHeight : kCompactButtonHeight,
       ),
-      side: light
-          ? BorderSide.none
-          : BorderSide(
-              color: fg.withOpacity(0.14),
-              width: 1,
-            ),
     ),
   );
 }


### PR DESCRIPTION
The snackbars are a bit too transparent. Plus the border does not render well on the transparent bg. Even when I increase both 
![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/1b9138fa-2ba5-412f-bd76-eba5ba15129c)

I would just axe the border here:
![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/c561ca0b-941d-4245-83c0-9f497ca1a3f4)
![grafik](https://github.com/ubuntu/yaru.dart/assets/15329494/83751f30-2d2c-4c0e-a3db-9a119ac1e522)
and increase opaqueness 