### PR TITLE
refactor: moved yaruvariant methods inside the enum

### DIFF
--- a/lib/src/themes/variant.dart
+++ b/lib/src/themes/variant.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:platform/platform.dart';
 import 'package:yaru/src/colors.dart';
 import 'package:yaru/src/themes/kubuntu.dart';
 import 'package:yaru/src/themes/lubuntu.dart';
@@ -75,6 +77,49 @@ enum YaruVariant {
     magenta,
     red,
   ];
+
+  static YaruVariant? _detect(Platform platform) {
+    final desktop = !kIsWeb
+        ? platform.environment['XDG_CURRENT_DESKTOP']?.toUpperCase()
+        : null;
+
+    if (desktop == null) {
+      return null;
+    }
+
+    if (desktop.contains('BUDGIE')) return YaruVariant.ubuntuBudgieBlue;
+    if (desktop.contains('CINNAMON')) return YaruVariant.ubuntuCinnamonBrown;
+    if (desktop.contains('GNOME')) return YaruVariant.orange;
+    if (desktop.contains('KDE')) return YaruVariant.kubuntuBlue;
+    if (desktop.contains('LXQT')) return YaruVariant.lubuntuBlue;
+    if (desktop.contains('MATE')) return YaruVariant.ubuntuMateGreen;
+    if (desktop.contains('UNITY')) return YaruVariant.ubuntuUnityPurple;
+    if (desktop.contains('XFCE')) return YaruVariant.xubuntuBlue;
+
+    return null;
+  }
+
+  static YaruVariant? resolve({required Platform platform, String? name}) {
+    if (name?.endsWith('-dark') == true) {
+      name = name!.substring(0, name.length - 5);
+    }
+
+    if (name?.startsWith('Yaru-') == true) {
+      name = name!.substring(5);
+    }
+
+    if (name == 'Yaru') {
+      return YaruVariant.orange;
+    }
+
+    for (final value in YaruVariant.values) {
+      if (value.name.toLowerCase() == name?.toLowerCase()) {
+        return value;
+      }
+    }
+
+    return _detect(platform);
+  }
 }
 
 final _yaruLightThemes = <YaruVariant, ThemeData>{

--- a/lib/src/widgets/inherited_theme.dart
+++ b/lib/src/widgets/inherited_theme.dart
@@ -7,23 +7,6 @@ import 'package:platform/platform.dart';
 import 'package:yaru/src/settings.dart';
 import 'package:yaru/yaru.dart';
 
-YaruVariant? _detectYaruVariant(Platform platform) {
-  final desktop = !kIsWeb
-      ? platform.environment['XDG_CURRENT_DESKTOP']?.toUpperCase()
-      : null;
-  if (desktop != null) {
-    if (desktop.contains('BUDGIE')) return YaruVariant.ubuntuBudgieBlue;
-    if (desktop.contains('CINNAMON')) return YaruVariant.ubuntuCinnamonBrown;
-    if (desktop.contains('GNOME')) return YaruVariant.orange;
-    if (desktop.contains('KDE')) return YaruVariant.kubuntuBlue;
-    if (desktop.contains('LXQT')) return YaruVariant.lubuntuBlue;
-    if (desktop.contains('MATE')) return YaruVariant.ubuntuMateGreen;
-    if (desktop.contains('UNITY')) return YaruVariant.ubuntuUnityPurple;
-    if (desktop.contains('XFCE')) return YaruVariant.xubuntuBlue;
-  }
-  return null;
-}
-
 /// Applies Yaru theme to descendant widgets.
 ///
 /// Descendant widgets obtain the current theme's [YaruThemeData] object using
@@ -153,7 +136,10 @@ class _YaruThemeState extends State<YaruTheme> {
     super.initState();
     if (widget.data.variant == null && canDetectVariant()) {
       _settings = widget._settings ?? YaruSettings();
-      _variant = resolveVariant(_settings?.getThemeName());
+      _variant = YaruVariant.resolve(
+        platform: widget._platform,
+        name: _settings?.getThemeName(),
+      );
       _subscription = _settings!.themeNameChanged.listen(updateVariant);
     }
   }
@@ -171,28 +157,18 @@ class _YaruThemeState extends State<YaruTheme> {
   }
 
   // "Yaru-prussiangreen-dark" => YaruAccent.prussianGreen
-  YaruVariant? resolveVariant(String? name) {
-    if (name?.endsWith('-dark') == true) {
-      name = name!.substring(0, name.length - 5);
-    }
-    if (name?.startsWith('Yaru-') == true) {
-      name = name!.substring(5);
-    }
-    if (name == 'Yaru') {
-      return YaruVariant.orange;
-    }
-    for (final value in YaruVariant.values) {
-      if (value.name.toLowerCase() == name?.toLowerCase()) {
-        return value;
-      }
-    }
-    return _detectYaruVariant(widget._platform);
-  }
 
   void updateVariant([String? value]) {
     assert(canDetectVariant());
     final name = value ?? _settings?.getThemeName();
-    setState(() => _variant = resolveVariant(name));
+    setState(
+      () {
+        _variant = YaruVariant.resolve(
+          platform: widget._platform,
+          name: name,
+        );
+      },
+    );
   }
 
   ThemeMode resolveMode() {


### PR DESCRIPTION
**Description**
This pull request addresses code organization concerns by relocating the methods of `YaruVariant` within the enum itself. This refactor takes advantage of the enhanced enums introduced in Dart 2.17. The primary goal is to centralize `YaruVariant` related code inside the enum itself.

This was one of the edit proposed in this pull request (#398), which i closed and splitted in more pull request as requested

Here is a brief video to show that the variant switch correctly
https://github.com/ubuntu/yaru.dart/assets/62995808/ee095f7d-10f7-4414-9396-1c907b676d00



